### PR TITLE
Passing simple enum by reference is suboptimial

### DIFF
--- a/server/src/chunk.rs
+++ b/server/src/chunk.rs
@@ -24,7 +24,7 @@ pub fn type_name_of_val<T: ?Sized>(_val: &T) -> &'static str {
 
 pub(crate) struct LegacyRecords(pub(crate) Vec<Record>);
 
-pub fn chunk_into_legacy(chunk: SegmentChunk, order: &Ordering) -> Vec<Record> {
+pub fn chunk_into_legacy(chunk: SegmentChunk, order: Ordering) -> Vec<Record> {
     let mut records = LegacyRecords::try_from(SchemaChunk {
         schema: legacy_schema(),
         chunk,
@@ -199,7 +199,7 @@ pub(crate) struct IndexedChunk {
     pub(crate) chunk: SegmentChunk,
 }
 impl IndexedChunk {
-    pub(crate) fn from_start(ix: RecordIndex, data: SchemaChunk<Schema>, order: &Ordering) -> Self {
+    pub(crate) fn from_start(ix: RecordIndex, data: SchemaChunk<Schema>, order: Ordering) -> Self {
         assert!(!data.chunk.arrays().is_empty());
         let start = ix.0 as i32;
         let size = data.chunk.len() as i32;
@@ -297,7 +297,7 @@ impl IndexedChunk {
     }
 
     #[cfg(test)]
-    pub(crate) fn into_legacy(self, order: &Ordering) -> Vec<Record> {
+    pub(crate) fn into_legacy(self, order: Ordering) -> Vec<Record> {
         chunk_into_legacy(self.chunk, order)
     }
 }

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -384,7 +384,7 @@ pub async fn topic_iterate(
             .await
     } else {
         topic
-            .get_records(position, page_size, &order, partition_filter)
+            .get_records(position, page_size, order, partition_filter)
             .await
     };
 
@@ -443,7 +443,7 @@ async fn partition_get_records(
         topic
             .get_partition(&partition_name)
             .await
-            .get_records(start_record, page_size, &Ordering::Forward)
+            .get_records(start_record, page_size, Ordering::Forward)
             .await
     };
 

--- a/server/src/manifest.rs
+++ b/server/src/manifest.rs
@@ -33,14 +33,14 @@ use crate::slog::{RecordIndex, SegmentIndex};
 
 pub const SEGMENT_FORMAT_VERSION: u16 = 1;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Ordering {
     Forward,
     Reverse,
 }
 
 impl Ordering {
-    fn to_sql_order(&self) -> &'static str {
+    fn to_sql_order(self) -> &'static str {
         match self {
             Self::Forward => "ASC",
             Self::Reverse => "DESC",
@@ -366,7 +366,7 @@ impl Manifest {
         &'a self,
         id: &'a PartitionId,
         start: RecordIndex,
-        order: &Ordering,
+        order: Ordering,
     ) -> impl futures::Stream<Item = SegmentData> + 'a + Send {
         let query = match order {
             Ordering::Forward => {

--- a/server/src/slog.rs
+++ b/server/src/slog.rs
@@ -380,7 +380,7 @@ impl Slog {
     ) -> Option<Record> {
         use crate::chunk::LegacyRecords;
 
-        self.iter_segment(segment, &Ordering::Forward)
+        self.iter_segment(segment, Ordering::Forward)
             .await
             .flat_map(|chunk| LegacyRecords::try_from(chunk).unwrap().0)
             .nth(relative)
@@ -389,7 +389,7 @@ impl Slog {
     pub(crate) async fn iter_segment<'a>(
         &'a self,
         ix: SegmentIndex,
-        order: &'a Ordering,
+        order: Ordering,
     ) -> Box<dyn DoubleEndedIterator<Item = SchemaChunk<Schema>> + Send + 'a> {
         let state = self.state.read().await;
         if ix > state.active_checkpoint.segment {


### PR DESCRIPTION
Passing simple enum by reference is suboptimal.
It is more idiomatic to derive `Copy` and pass by value.