### PR TITLE
ENG-3816 byte limit for active segments

### DIFF
--- a/server/src/slog.rs
+++ b/server/src/slog.rs
@@ -499,6 +499,7 @@ impl Slog {
     }
 
     pub(crate) async fn checkpoint(&self) -> bool {
+        trace!("checkpoint {:?}", self.root);
         self.state.write().await.checkpoint(false).await
     }
 


### PR DESCRIPTION
tl;dr: limit the amount of active chunks stored in memory to avoid OOMs

We do this by closing the oldest partition once we hit a configurable threshold, until we fall below that line. I originally had this set up to close the largest partition, but went with oldest (specifically oldest last write) as that should help avoid thrashing.

With this done, we can dramatically raise the active topic limit (16 => 128). We may be able to raise it even higher / remove it entirely, but I'd want to do more testing before trying that.

In an ideal world we'd probably "preallocate" space before insert, but this at least gets us much closer to what we need.