### PR TITLE
Include sqlite manifest in catalog size computation

### DIFF
--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -434,7 +434,7 @@ mod test {
     #[tokio::test]
     async fn test_retain() -> Result<()> {
         let (_root, mut catalog) = catalog().await;
-        catalog.config.retain.max_bytes = ByteSize::b(8000);
+        catalog.config.retain.max_bytes = ByteSize::b(8000 + catalog.manifest.db_bytes() as u64);
 
         let data = "x".to_string().repeat(500);
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -55,7 +55,7 @@ pub fn env_source() -> config::Environment {
 
 pub fn binary_config() -> Result<PlateauConfig> {
     let config = Config::builder()
-        .set_default("catalog.retain.max_bytes", "95GiB")?
+        .set_default("catalog.retain.max_bytes", "99GiB")?
         .add_source(File::with_name("/etc/plateau.yaml").required(false))
         .add_source(File::with_name("./plateau.yaml").required(false))
         .add_source(File::with_name("/etc/plateau.toml").required(false))


### PR DESCRIPTION
I've wanted to do this for a while, and it's pretty self explanatory. While we can't keep sqlite size constant, we can include it in the overall catalog size computation.

This obviously becomes a problem if the manifest ever gets quite large... but that's a bug in and of itself, it shouldn't happen in any useful scenario I can envision.

This should let us hew much closer to the actual size of the disk, as we no longer need to worry about the manifest chewing through our headroom. I bumped the associated quota appropriately (95Gi => 99Gi, where the PV by default is 100Gi).