### PR TITLE
Fix nulling of nested oversize columns

### DIFF
--- a/server/tests/server.rs
+++ b/server/tests/server.rs
@@ -593,6 +593,7 @@ async fn large_appends() -> Result<()> {
             &TopicIterationQuery {
                 data_focus: DataFocus {
                     dataset: vec!["*".into()],
+                    dataset_separator: Some(".".into()),
                     max_bytes: Some(100 * 1024),
                     ..Default::default()
                 },
@@ -605,16 +606,16 @@ async fn large_appends() -> Result<()> {
     assert_eq!(
         json.value,
         json::json!([
-            {"tensor": null, "time": 0},
-            {"tensor": null, "time": 1},
-            {"tensor": null, "time": 2},
-            {"tensor": null, "time": 3},
-            {"tensor": null, "time": 4},
-            {"tensor": null, "time": 0},
-            {"tensor": null, "time": 1},
-            {"tensor": null, "time": 2},
-            {"tensor": null, "time": 3},
-            {"tensor": null, "time": 4},
+            {"out.tensor": null, "time": 0},
+            {"out.tensor": null, "time": 1},
+            {"out.tensor": null, "time": 2},
+            {"out.tensor": null, "time": 3},
+            {"out.tensor": null, "time": 4},
+            {"out.tensor": null, "time": 0},
+            {"out.tensor": null, "time": 1},
+            {"out.tensor": null, "time": 2},
+            {"out.tensor": null, "time": 3},
+            {"out.tensor": null, "time": 4},
         ])
     );
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -77,17 +77,23 @@ pub fn inferences_large_extension(count: i64, inner_size: i64, shape: &str) -> S
         None,
     );
 
+    let out = StructArray::new(
+        DataType::Struct(vec![Field::new("tensor", tensor.data_type().clone(), true)]),
+        vec![tensor.boxed()],
+        None,
+    );
+
     let schema = Schema {
         fields: vec![
             Field::new("time", time.data_type().clone(), false),
-            Field::new("tensor", tensor.data_type().clone(), false),
+            Field::new("out", out.data_type().clone(), false),
         ],
         metadata: Metadata::default(),
     };
 
     SchemaChunk {
         schema,
-        chunk: Chunk::try_new(vec![time.boxed(), tensor.boxed()]).unwrap(),
+        chunk: Chunk::try_new(vec![time.boxed(), out.boxed()]).unwrap(),
     }
 }
 


### PR DESCRIPTION
tl;dr we weren't doing the size nulling procedure when unnesting columns via `dataset.separator`

We can fix that and update our integration testing dataset to closer match the actual data schema.