### PR TITLE
Bump to 0.5.2; bugfix arrow2 records parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/WallarooLabs/arrow2?branch=fmurphy/match-polars#6b11aebf8204942796a434e6e92dec90bb18b085"
+source = "git+https://github.com/WallarooLabs/arrow2?branch=fmurphy/bugfix-records-parsing#634b8c8a9d0461dba4c0ec308d76158d6f707cf1"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -335,7 +335,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bench"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "plateau"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "plateau-server",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-client"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-test"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "plateau-client",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-transport"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arrow2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["client", "server", "transport", "cli", "bench", "plateau", "test"]
 
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Wallaroo Labs"]
 repository = "https://github.com/WallarooLabs/plateau"
@@ -25,7 +25,7 @@ debug = true
 
 
 [patch.crates-io]
-arrow2 = { git = "https://github.com/WallarooLabs/arrow2", branch = "fmurphy/match-polars" }
+arrow2 = { git = "https://github.com/WallarooLabs/arrow2", branch = "fmurphy/bugfix-records-parsing" }
 parquet2 = { git = "https://github.com/WallarooLabs/parquet2", branch = "more-writer-details" }
 
 

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -13,7 +13,7 @@ serde = "1"
 serde_with = "3.7"
 rweb = { version = "0.15", features = ["openapi"], optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
-arrow2 = { git = "https://github.com/WallarooLabs/arrow2", branch = "fmurphy/match-polars", features = [
+arrow2 = { git = "https://github.com/WallarooLabs/arrow2", branch = "fmurphy/bugfix-records-parsing", features = [
   "compute_aggregate",
   "compute_cast",
   "compute_comparison",


### PR DESCRIPTION
The associated change is this commit: https://github.com/WallarooLabs/arrow2/commit/634b8c8a9d0461dba4c0ec308d76158d6f707cf1