### PR TITLE
Expose topic stored bytes via gauges and API

### DIFF
--- a/catalog/src/manifest.rs
+++ b/catalog/src/manifest.rs
@@ -469,7 +469,7 @@ impl Manifest {
         .unwrap();
     }
 
-    /// Get the total stored byte size of a given partition.
+    /// Get the total stored byte size of a given catalog, topic, or partition.
     pub async fn get_size(&self, scope: Scope<'_>) -> usize {
         let query = match scope {
             Scope::Global => sqlx::query("SELECT SUM(size) AS size FROM segments"),

--- a/catalog/src/topic.rs
+++ b/catalog/src/topic.rs
@@ -11,7 +11,7 @@ use crate::data::{
     limit::{BatchStatus, LimitedBatch, RowLimit},
     records::{LegacyRecords, Record},
 };
-use crate::manifest::{Manifest, PartitionId, SegmentData};
+use crate::manifest::{Manifest, PartitionId, Scope, SegmentData};
 
 use crate::partition::Config as PartitionConfig;
 use crate::partition::Partition;
@@ -80,6 +80,10 @@ impl Topic {
             partition_filter,
         )
         .await
+    }
+
+    pub async fn byte_size(&self) -> usize {
+        self.manifest.get_size(Scope::Topic(&self.name)).await
     }
 
     async fn partition_names(&self) -> Vec<String> {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1055,6 +1055,7 @@ mod tests {
                     .drain(..)
                     .map(|p| (p.to_owned(), Span { start: 0, end: 100 }))
                     .collect(),
+                bytes: 200,
             })),
         );
 

--- a/transport/src/lib.rs
+++ b/transport/src/lib.rs
@@ -164,6 +164,7 @@ pub struct Inserted {
 #[cfg_attr(feature = "rweb", derive(Schema))]
 pub struct Partitions {
     pub partitions: HashMap<String, Span>,
+    pub bytes: usize,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, ToSchema)]


### PR DESCRIPTION
Example gauges from `catalog::test::test_retain` (the actual prometheus gauge is `topic_bytes`):

```
2025-08-15T00:41:17.844241Z TRACE gauge_topics: plateau_catalog::catalog: labels=[("topic", "oldest")] bytes=11752
2025-08-15T00:41:17.844548Z TRACE gauge_topics: plateau_catalog::catalog: labels=[("topic", "topic-0")] bytes=5876
2025-08-15T00:41:17.844855Z TRACE gauge_topics: plateau_catalog::catalog: labels=[("topic", "topic-4")] bytes=5876
2025-08-15T00:41:17.845120Z TRACE gauge_topics: plateau_catalog::catalog: labels=[("topic", "topic-1")] bytes=5876
2025-08-15T00:41:17.845371Z TRACE gauge_topics: plateau_catalog::catalog: labels=[("topic", "topic-2")] bytes=5876
2025-08-15T00:41:17.845698Z TRACE gauge_topics: plateau_catalog::catalog: labels=[("topic", "topic-3")] bytes=5876
```