### PR TITLE
Pin to 1.89.0 during migration

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.89.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This way we don't need to fix common lint failures twice while we have an entirely separate `arrow-rs` partial copy.