### PR TITLE
Tolerate already-removed files in segment destroy paths

### DIFF
--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -19,14 +19,13 @@
 use std::io::Read;
 use std::{fs, path::Path, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{error, trace, warn};
 
 // Use arrow-rs Schema instead of arrow2 Schema
 use arrow_schema::Schema;
 use plateau_transport::SegmentChunk;
-
 #[allow(dead_code)]
 mod arrow;
 mod cache;
@@ -34,6 +33,23 @@ mod cache;
 // mod parquet;
 
 const PLATEAU_HEADER: &str = "plateau1";
+
+/// Remove a file, tolerating the case where it has already been removed.
+///
+/// Retention and (eventually) reconciliation can both delete the same segment
+/// file, so the loser of that race finds it already gone. A missing file is
+/// logged at `warn` and treated as success; every other error (permissions,
+/// I/O, ...) propagates.
+fn remove_file_if_present(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            warn!("attempted to remove missing file {:?}", path);
+            Ok(())
+        }
+        other => other.context(format!("removing {path:?}")),
+    }
+}
 
 fn validate_header(mut reader: impl Read) -> Result<()> {
     let mut buffer = [0u8; 8];
@@ -120,20 +136,20 @@ impl Segment {
     }
 
     pub fn destroy(&self) -> Result<()> {
-        if self.path.exists() {
-            fs::remove_file(&self.path)?;
-        } else {
-            warn!("main segment file at {:?} missing", self.path);
-        }
+        // The main segment file is expected to exist; a missing one is worth a
+        // warning (e.g. a concurrent remover beat us to it) but not an error.
+        remove_file_if_present(&self.path)?;
 
+        // Parts and the active-chunk cache are auxiliary and routinely absent,
+        // so only attempt the ones present. Routing through the tolerant helper
+        // still lets a remove that loses a race no-op while propagating any
+        // genuine I/O error (previously these were swallowed).
         for part in self.parts().filter(|p| p.exists()) {
-            fs::remove_file(&part)
-                .inspect_err(|e| error!("error removing part {part:?}: {e:?}"))
-                .ok();
+            remove_file_if_present(&part)?;
         }
 
         if self.cache_path().exists() {
-            fs::remove_file(self.cache_path())?;
+            remove_file_if_present(&self.cache_path())?;
         }
 
         Ok(())

--- a/data/src/segment/cache.rs
+++ b/data/src/segment/cache.rs
@@ -71,8 +71,11 @@ impl ActiveChunk {
     }
 
     pub fn destroy(&mut self) -> Result<()> {
+        // The active-chunk cache is routinely absent (it is discarded as chunks
+        // fill), so only attempt to remove it when present. The tolerant helper
+        // still no-ops on a lost race and propagates any genuine I/O error.
         if Path::exists(&self.path) {
-            fs::remove_file(&self.path)?;
+            super::remove_file_if_present(&self.path)?;
         }
         self.writer = None;
 


### PR DESCRIPTION
Retention (and, eventually, reconciliation orphan removal) can race to delete the same segment file; the loser previously hit an error because the removes used a check-then-act exists() guard with a TOCTOU gap, and parts were swallowing all errors indiscriminately.

Route the retention/write-side removes through a remove_file_if_present helper: a missing file is logged at warn and treated as success, while every other error (permissions, I/O) propagates. Auxiliary files (parts, active-chunk cache) keep their exists() pre-filter so routine absence is not warned about; the helper only fires on a genuine lost race.

https://claude.ai/code/session_015TrQsjcw47MKub49Yoqx1c