### PR TITLE
Run reconciliation continuously in a background loop

### DIFF
--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -480,7 +480,10 @@ impl ReconcileJob {
                         mode = ?report.mode,
                         "reconcile pass complete"
                     );
-                    gauge!("reconcile_last_pass_ms").set(elapsed.as_millis() as f64);
+                    // Record the pass duration in seconds (Duration's IntoF64
+                    // impl), matching the prometheus/openmetrics convention of
+                    // unitless-second gauges and preserving sub-second precision.
+                    gauge!("reconcile_last_pass").set(elapsed);
                     catalog.publish_reconcile_report(Arc::new(report));
                 }
                 Err(e) => {
@@ -2014,8 +2017,8 @@ mod tests {
             // The first pass completes promptly.
             rx.changed().await.unwrap();
             assert!(rx.borrow_and_update().is_some());
-            // The next pass must be gated by the 30s interval, so it does not
-            // publish within a short window.
+            // The second pass is gated by the 30s `pass_interval`, so it must
+            // not publish within a 300ms observation window (well short of 30s).
             let second = tokio::time::timeout(Duration::from_millis(300), rx.changed()).await;
             assert!(
                 second.is_err(),

--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -20,9 +20,11 @@ use tokio::sync::OwnedMutexGuard;
 use crate::data::segment::Segment;
 use anyhow::Result;
 use bytesize::ByteSize;
+use chrono::{DateTime, Utc};
 use futures::stream::StreamExt;
+use metrics::gauge;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::catalog::Catalog;
 use crate::data::RecordIndex;
@@ -41,7 +43,7 @@ fn is_sealed(sealed_ix: Option<SegmentIndex>, index: SegmentIndex) -> bool {
 }
 
 /// Configuration for the reconciliation job
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ReconcileConfig {
     /// Maximum units of work to process in a single run
@@ -55,6 +57,37 @@ pub struct ReconcileConfig {
     /// Set of fixes to apply during reconciliation
     #[serde(default)]
     pub fixes: BTreeSet<ReconcileFix>,
+    /// Delay between *completed* reconciliation passes in the continuous loop
+    /// ([ReconcileJob::run_loop]). `idle_ratio` paces work *within* a pass; this
+    /// paces the gap *between* passes so a healthy system reconciles
+    /// periodically rather than busy-looping. `None` runs passes back-to-back
+    /// (still paced by `idle_ratio`). Defaults to a few minutes.
+    #[serde(
+        default = "ReconcileConfig::default_pass_interval",
+        with = "humantime_serde"
+    )]
+    pub pass_interval: Option<Duration>,
+}
+
+impl Default for ReconcileConfig {
+    fn default() -> Self {
+        Self {
+            limit: None,
+            idle_ratio: 0.0,
+            track_files: false,
+            fixes: BTreeSet::new(),
+            pass_interval: Self::default_pass_interval(),
+        }
+    }
+}
+
+impl ReconcileConfig {
+    /// Default gap between completed reconciliation passes. A few minutes keeps
+    /// the system's consistency view fresh without spending the box's IO budget
+    /// re-scanning back-to-back.
+    fn default_pass_interval() -> Option<Duration> {
+        Some(Duration::from_secs(300))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -292,6 +325,12 @@ pub struct ReconcileReport {
     /// because another fix-enabled pass already held the single-flight guard.
     /// `None` for passes that ran as configured (whether fixing or report-only).
     pub fixes_skipped_reason: Option<String>,
+    /// Wall-clock time the pass that produced this report completed. Stamped by
+    /// the continuous loop ([ReconcileJob::run_loop]) just before publishing, so
+    /// operators can tell from `/info` how fresh the consistency view is. `None`
+    /// on reports that were never published through the loop (e.g. a report read
+    /// directly off a [ReconcileJob] mid-pass, or constructed in tests).
+    pub last_pass_completed_at: Option<DateTime<Utc>>,
 }
 
 impl ReconcileReport {
@@ -401,6 +440,66 @@ impl ReconcileJob {
         }
 
         result
+    }
+
+    /// Run reconciliation continuously, one pass after another, until this
+    /// future is dropped. Cancellation is by drop: on server shutdown the
+    /// `select_all` race in the server task drops this future at its next await
+    /// point, releasing any single-flight guard held by the in-flight pass. The
+    /// loop therefore takes no explicit stop signal.
+    ///
+    /// Each completed pass publishes its report to the catalog (so `/info` reads
+    /// the freshest view) and stamps [ReconcileReport::last_pass_completed_at].
+    /// A single [ReconcileJob] is reused across passes via [Self::reset], which
+    /// re-arms the single-flight decision so each pass scans the catalog afresh.
+    ///
+    /// A pass that returns `Err` is logged at error level and does *not*
+    /// terminate the loop — the next pass simply starts after `pass_interval`.
+    /// Reconcile errors are rare but must never wedge this long-running task.
+    pub async fn run_loop(catalog: Arc<Catalog>, config: ReconcileConfig) {
+        let pass_interval = config.pass_interval;
+        let mut job = Self::with_config(catalog.clone(), config);
+
+        loop {
+            let started = Instant::now();
+            debug!("reconcile pass starting");
+            match job.run(None).await {
+                Ok(_) => {
+                    let elapsed = started.elapsed();
+                    // Stamp completion time on the published report so freshness
+                    // is observable from /info and tests.
+                    let mut report = job.report().clone();
+                    report.last_pass_completed_at = Some(Utc::now());
+                    info!(
+                        elapsed_ms = elapsed.as_millis(),
+                        files_checked = report.sealed.files_checked.len(),
+                        size_mismatches = report.sealed.size_mismatches.len(),
+                        missing_files = report.sealed.missing_files.len(),
+                        untracked_files = report.sealed.untracked_files.len(),
+                        active_segments = report.active.len(),
+                        mode = ?report.mode,
+                        "reconcile pass complete"
+                    );
+                    gauge!("reconcile_last_pass_ms").set(elapsed.as_millis() as f64);
+                    catalog.publish_reconcile_report(Arc::new(report));
+                }
+                Err(e) => {
+                    // Swallow the error and keep the loop alive; a transient
+                    // failure on one pass must not stop reconciliation forever.
+                    error!("reconcile pass failed, continuing loop: {e:?}");
+                }
+            }
+
+            // Re-arm for a fresh pass (also releases the single-flight guard if
+            // the completed pass held it).
+            job.reset().await;
+
+            // Pace between completed passes. `idle_ratio` already paces within a
+            // pass; this is the gap before the next one starts.
+            if let Some(interval) = pass_interval {
+                tokio::time::sleep(interval).await;
+            }
+        }
     }
 
     /// Drive incremental units of work up to the effective limit, returning
@@ -1772,6 +1871,166 @@ mod tests {
             catalog.reconcile_fix_guard().try_lock_owned().is_ok(),
             "single-flight guard must be released after an errored fix pass"
         );
+
+        Ok(())
+    }
+
+    /// Seed a catalog with a single committed partition and flush it to disk so
+    /// reconciliation passes have real work to do.
+    async fn seed_catalog(catalog: &Catalog, topic_name: &str, partition_name: &str) {
+        let topic = catalog.get_topic(topic_name).await;
+        topic
+            .extend_records(partition_name, &test_records(&["a", "b", "c"]))
+            .await
+            .unwrap();
+        topic.commit().await.unwrap();
+        drop(topic);
+        catalog.checkpoint().await;
+    }
+
+    /// The continuous loop runs passes back-to-back: with a short `pass_interval`
+    /// the ArcSwap-published snapshot advances at least twice within a bounded
+    /// time. Cancellation is by dropping the loop future (here via `select!`).
+    #[test_log::test(tokio::test)]
+    async fn test_loop_runs_multiple_passes() -> Result<()> {
+        let (_tmp, catalog) = create_test_catalog().await;
+        seed_catalog(&catalog, "t", "p").await;
+
+        let config = ReconcileConfig {
+            track_files: true,
+            pass_interval: Some(Duration::from_millis(1)),
+            ..Default::default()
+        };
+
+        let mut rx = catalog.subscribe_reconcile_report();
+        let observe = async {
+            rx.changed().await.unwrap();
+            let first = rx
+                .borrow_and_update()
+                .clone()
+                .expect("first report published");
+            rx.changed().await.unwrap();
+            let second = rx
+                .borrow_and_update()
+                .clone()
+                .expect("second report published");
+            (first, second)
+        };
+
+        let (first, second) = tokio::select! {
+            _ = ReconcileJob::run_loop(catalog.clone(), config) => {
+                unreachable!("the loop runs until dropped")
+            }
+            out = tokio::time::timeout(Duration::from_secs(5), observe) => {
+                out.expect("two passes should complete within 5s")
+            }
+        };
+
+        // Each completed pass stamps its completion time and is a distinct
+        // publication.
+        assert!(first.last_pass_completed_at.is_some());
+        assert!(second.last_pass_completed_at.is_some());
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "each pass should publish a fresh report"
+        );
+
+        Ok(())
+    }
+
+    /// An error inside a pass is logged and swallowed: the loop keeps going and
+    /// publishes a successful pass once the underlying problem is cleared.
+    #[test_log::test(tokio::test)]
+    async fn test_loop_survives_pass_error() -> Result<()> {
+        let (_tmp, catalog) = create_test_catalog().await;
+        let topic_name = "broken-loop";
+        let partition_name = "p0";
+        seed_catalog(&catalog, topic_name, partition_name).await;
+
+        // Replace the topic directory with a regular file so the orphan-detection
+        // `read_dir` fails and every pass errors until we repair it.
+        let topic_path = Topic::partition_root(catalog.topic_root(), topic_name);
+        fs::remove_dir_all(&topic_path).await?;
+        fs::write(&topic_path, b"not a directory").await?;
+
+        let config = ReconcileConfig {
+            track_files: true,
+            pass_interval: Some(Duration::from_millis(10)),
+            ..Default::default()
+        };
+
+        let mut rx = catalog.subscribe_reconcile_report();
+        let observe = async {
+            // Let the loop attempt (and fail) at least one pass. No report can be
+            // published while the directory is broken.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            assert!(
+                rx.borrow_and_update().is_none(),
+                "no pass should complete while the topic directory is broken"
+            );
+
+            // Repair the directory; subsequent passes succeed.
+            fs::remove_file(&topic_path).await.unwrap();
+            fs::create_dir_all(&topic_path).await.unwrap();
+
+            // The loop must have survived the errors and now publishes a pass.
+            rx.changed().await.unwrap();
+            rx.borrow_and_update()
+                .clone()
+                .expect("a report after recovery")
+        };
+
+        let report = tokio::select! {
+            _ = ReconcileJob::run_loop(catalog.clone(), config) => {
+                unreachable!("the loop runs until dropped")
+            }
+            out = tokio::time::timeout(Duration::from_secs(5), observe) => {
+                out.expect("the loop should recover within 5s")
+            }
+        };
+
+        assert!(report.last_pass_completed_at.is_some());
+
+        Ok(())
+    }
+
+    /// `pass_interval` gates the gap between passes: with a long interval the
+    /// second pass does not start until the delay elapses, even though
+    /// `idle_ratio` is zero (no within-pass pacing).
+    #[test_log::test(tokio::test)]
+    async fn test_pass_interval_gates_next_pass() -> Result<()> {
+        let (_tmp, catalog) = create_test_catalog().await;
+        seed_catalog(&catalog, "t", "p").await;
+
+        let config = ReconcileConfig {
+            track_files: true,
+            idle_ratio: 0.0,
+            pass_interval: Some(Duration::from_secs(30)),
+            ..Default::default()
+        };
+
+        let mut rx = catalog.subscribe_reconcile_report();
+        let observe = async {
+            // The first pass completes promptly.
+            rx.changed().await.unwrap();
+            assert!(rx.borrow_and_update().is_some());
+            // The next pass must be gated by the 30s interval, so it does not
+            // publish within a short window.
+            let second = tokio::time::timeout(Duration::from_millis(300), rx.changed()).await;
+            assert!(
+                second.is_err(),
+                "second pass must wait for pass_interval before starting"
+            );
+        };
+
+        tokio::select! {
+            _ = ReconcileJob::run_loop(catalog.clone(), config) => {
+                unreachable!("the loop runs until dropped")
+            }
+            out = tokio::time::timeout(Duration::from_secs(5), observe) => {
+                out.expect("the first pass should complete within 5s")
+            }
+        }
 
         Ok(())
     }

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -543,37 +543,44 @@ async fn get_info(
     // into the catalog on completion; here we take a lock-free snapshot so the
     // response never blocks on an in-flight pass. If no pass has completed yet,
     // return a pending placeholder with zeroed stats.
-    let (retention_stats, active_segments, pending) = match catalog.latest_reconcile_report() {
-        Some(report) => {
-            let sealed = &report.sealed;
-            let retention_stats = ReconcileStats {
-                files_checked: sealed.files_checked.len(),
-                untracked_files: sealed.untracked_files.len(),
-                size_mismatches: sealed.size_mismatches.len(),
-                missing_files: sealed.missing_files.len(),
-                expected_size: sealed.expected_size.as_u64() as usize,
-                actual_size: sealed.actual_size.as_u64() as usize,
-            };
-            let active_segments = report
-                .active
-                .iter()
-                .map(|a| ActiveSegmentReport {
-                    topic: a.topic.clone(),
-                    partition: a.partition.clone(),
-                    manifest_size: a.manifest_size,
-                    disk_size: a.disk_size,
-                    delta: a.delta,
-                })
-                .collect();
-            (retention_stats, active_segments, false)
-        }
-        None => (ReconcileStats::default(), Vec::new(), true),
-    };
+    let (retention_stats, active_segments, last_reconcile_pass_completed_at, pending) =
+        match catalog.latest_reconcile_report() {
+            Some(report) => {
+                let sealed = &report.sealed;
+                let retention_stats = ReconcileStats {
+                    files_checked: sealed.files_checked.len(),
+                    untracked_files: sealed.untracked_files.len(),
+                    size_mismatches: sealed.size_mismatches.len(),
+                    missing_files: sealed.missing_files.len(),
+                    expected_size: sealed.expected_size.as_u64() as usize,
+                    actual_size: sealed.actual_size.as_u64() as usize,
+                };
+                let active_segments = report
+                    .active
+                    .iter()
+                    .map(|a| ActiveSegmentReport {
+                        topic: a.topic.clone(),
+                        partition: a.partition.clone(),
+                        manifest_size: a.manifest_size,
+                        disk_size: a.disk_size,
+                        delta: a.delta,
+                    })
+                    .collect();
+                (
+                    retention_stats,
+                    active_segments,
+                    report.last_pass_completed_at,
+                    false,
+                )
+            }
+            None => (ReconcileStats::default(), Vec::new(), None, true),
+        };
 
     Ok(Response::ok(InfoResponse {
         topics,
         retention_stats,
         active_segments,
+        last_reconcile_pass_completed_at,
         pending,
     }))
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -78,35 +78,22 @@ pub async fn task_from_catalog_config(
 ) -> bool {
     let (addr, end_tx, server) = http::serve(config.clone(), catalog.clone()).await;
 
-    // Start reconciliation task if configured
-    if let Some(reconcile_config) = &config.reconcile {
-        tracing::info!(
-            "starting reconciliation task with config: {:?}",
-            reconcile_config
-        );
-        let mut reconciler =
-            catalog::ReconcileJob::with_config(catalog.clone(), reconcile_config.clone());
-        let publish_catalog = catalog.clone();
-
-        tokio::spawn(async move {
-            // Run reconciliation once and publish the result so /info can read
-            // the latest snapshot. The continuous loop comes later; for now this
-            // single completed pass becomes queryable.
-            match reconciler.run(None).await {
-                Ok(_) => {
-                    publish_catalog.publish_reconcile_report(Arc::new(reconciler.report().clone()));
-                    tracing::info!("reconciliation completed successfully");
-                }
-                Err(e) => {
-                    tracing::error!("reconciliation error: {:?}", e);
-                }
-            }
-        });
-    }
-
     {
         use futures::future::FutureExt;
         let mut tasks = vec![Catalog::checkpoints(catalog.clone()).boxed(), stop, server];
+
+        // Run reconciliation continuously if configured. The loop runs passes
+        // back-to-back (paced by the config), publishing each completed report
+        // into the catalog so /info reflects the freshest consistency view. It
+        // joins the shutdown race here: when `stop` (or the server) wins the
+        // `select_all`, this future is dropped, cleanly cancelling the loop.
+        if let Some(reconcile_config) = config.reconcile.clone() {
+            tracing::info!(
+                "starting continuous reconciliation loop with config: {:?}",
+                reconcile_config
+            );
+            tasks.push(catalog::ReconcileJob::run_loop(catalog.clone(), reconcile_config).boxed());
+        }
 
         if config.catalog.storage.monitor {
             tasks.push(catalog.monitor_disk_storage().boxed());

--- a/server/tests/server.rs
+++ b/server/tests/server.rs
@@ -1215,3 +1215,138 @@ async fn info_not_racy_with_reconcile() -> Result<()> {
     reconcile.await??;
     Ok(())
 }
+
+/// Repeatedly hit `/info` until `pred` holds, returning the matching response.
+/// Panics if the condition is not reached within a bounded time.
+async fn poll_info_until<F>(client: &Client, url: &str, mut pred: F) -> json::Value
+where
+    F: FnMut(&json::Value) -> bool,
+{
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Ok(info) = get_json(client, url).await {
+                if pred(&info) {
+                    return info;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("/info did not reach the expected state within 10s")
+}
+
+/// The continuous reconciliation loop keeps `/info` current: a pass reports a
+/// freshly-introduced orphan, and once the orphan is removed a later pass
+/// reports the partition clean. `/info` always reflects the most recent pass,
+/// including an advancing completion timestamp.
+#[test_log::test(tokio::test)]
+async fn info_reflects_latest_reconcile_pass() -> Result<()> {
+    let (client, topic_name, server) = setup().await;
+
+    // Write and flush a partition so its topic directory exists on disk.
+    repeat_append(
+        &client,
+        append_url(&server, &topic_name, PARTITION_NAME).as_str(),
+        TEST_MESSAGE,
+        5,
+    )
+    .await;
+    server.catalog.checkpoint().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Drop an orphan file into the topic directory so the next pass flags it.
+    let topic_dir = server.catalog.topic_root().join(&topic_name);
+    let orphan = topic_dir.join("orphan-reconcile-loop");
+    std::fs::write(&orphan, b"orphan").unwrap();
+
+    // Run the continuous loop against this catalog: report-only, fast passes.
+    let loop_handle = tokio::spawn(catalog::ReconcileJob::run_loop(
+        server.catalog.clone(),
+        catalog::ReconcileConfig {
+            track_files: true,
+            pass_interval: Some(Duration::from_millis(10)),
+            ..Default::default()
+        },
+    ));
+
+    // A pass reports the orphan; /info reflects it and stamps a completion time.
+    let dirty = poll_info_until(&client, &info_url(&server), |info| {
+        info["pending"] == json::json!(false)
+            && info["retention_stats"]["untracked_files"].as_u64() == Some(1)
+    })
+    .await;
+    let first_ts = dirty["last_reconcile_pass_completed_at"].clone();
+    assert!(
+        first_ts.is_string(),
+        "a completed pass must stamp a completion timestamp"
+    );
+
+    // Clear the underlying issue; a strictly newer pass must report it clean.
+    std::fs::remove_file(&orphan).unwrap();
+    let clean = poll_info_until(&client, &info_url(&server), |info| {
+        info["retention_stats"]["untracked_files"].as_u64() == Some(0)
+            && info["last_reconcile_pass_completed_at"].is_string()
+            && info["last_reconcile_pass_completed_at"] != first_ts
+    })
+    .await;
+    assert_ne!(
+        clean["last_reconcile_pass_completed_at"], first_ts,
+        "/info must reflect a newer reconcile pass"
+    );
+
+    loop_handle.abort();
+    Ok(())
+}
+
+/// The reconciliation loop joins the server's shutdown race: when the stop
+/// signal fires, the loop is dropped and the server task returns a clean close
+/// within a bounded time (no hang, no panic).
+#[test_log::test(tokio::test)]
+async fn reconcile_loop_cancels_on_shutdown() -> Result<()> {
+    use plateau::Catalog;
+
+    let temp = tempfile::tempdir()?;
+    let config = PlateauConfig {
+        data_path: temp.path().to_path_buf(),
+        http: http::Config::localhost(),
+        reconcile: Some(catalog::ReconcileConfig {
+            track_files: true,
+            pass_interval: Some(Duration::from_millis(10)),
+            ..Default::default()
+        }),
+        ..PlateauConfig::default()
+    };
+
+    let catalog =
+        Arc::new(Catalog::attach(config.data_path.clone(), config.catalog.clone()).await?);
+
+    // Watch pass completions without retaining a Catalog Arc: the receiver is
+    // independent of the catalog handle, so `close_arc` can still unwrap the
+    // last reference during shutdown.
+    let mut report_rx = catalog.subscribe_reconcile_report();
+
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let stop = Box::pin(async move {
+        let _ = stop_rx.await;
+    });
+    let task = tokio::spawn(plateau::task_from_catalog_config(catalog, config, stop));
+
+    // Let the loop complete at least one pass so it is genuinely running.
+    tokio::time::timeout(Duration::from_secs(5), report_rx.changed())
+        .await
+        .expect("a reconcile pass should complete before shutdown")?;
+
+    // Trigger shutdown: the loop future is dropped by the select_all race.
+    stop_tx.send(()).unwrap();
+
+    let clean = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server task must shut down within 5s")?;
+    assert!(
+        clean,
+        "catalog should close cleanly after the loop is cancelled"
+    );
+
+    Ok(())
+}

--- a/transport/src/lib.rs
+++ b/transport/src/lib.rs
@@ -472,6 +472,14 @@ pub struct InfoResponse {
     /// Defaulted on deserialization so older clients and payloads remain valid.
     #[serde(default)]
     pub pending: bool,
+    /// Wall-clock time the most recent reconciliation pass completed, as stamped
+    /// by the continuous reconciliation loop. Lets operators judge how fresh the
+    /// reconciliation view is. `None` until the first pass completes (in which
+    /// case `pending` is also true).
+    ///
+    /// Defaulted on deserialization so older clients and payloads remain valid.
+    #[serde(default)]
+    pub last_reconcile_pass_completed_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
Replace the run-once reconcile spawn with a continuous loop that runs passes back-to-back for the lifetime of the server, keeping a fresh view of catalog consistency.

- ReconcileJob::run_loop reuses a single job via reset() between passes, publishing each completed report into the catalog's ArcSwap/watch so /info reads the freshest snapshot. The loop takes no explicit stop signal: it joins the server's select_all shutdown race and is cancelled cleanly by being dropped, which also releases any single-flight guard.
- A pass that returns Err is logged at error level and does not terminate the loop; the next pass starts after the configured interval.
- ReconcileConfig.pass_interval (Option<Duration>, default 5m) paces the gap between completed passes; None runs back-to-back, still paced by idle_ratio within a pass.
- Each completed pass logs one summary line, sets a reconcile_last_pass_ms gauge, and stamps ReconcileReport.last_pass_completed_at, surfaced on /info as last_reconcile_pass_completed_at so operators can judge reconciliation freshness.

Tests: loop runs multiple passes; survives a transient pass error and recovers; pass_interval gates the next pass; shutdown cancels the loop within a bounded time with a clean catalog close; /info reflects the most recent pass (dirty -> clean) with an advancing completion timestamp.