### PR TITLE
Reconcile soak test

### DIFF
--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -5,7 +5,7 @@
 //! - Verify file sizes on disk match sizes in the manifest
 //! - Detect files that don't belong to any segment in their directory
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::iter;
 use std::mem;
 use std::path::{Path, PathBuf};
@@ -40,6 +40,26 @@ use crate::topic::Topic;
 /// sealed durably yet) every segment is treated as active.
 fn is_sealed(sealed_ix: Option<SegmentIndex>, index: SegmentIndex) -> bool {
     sealed_ix.is_some_and(|watermark| index <= watermark)
+}
+
+/// Parse the partition name and segment index out of a segment file *stem* of
+/// the form `{topic}-{partition}-{index}` (see [Partition::slog_name] and
+/// [Slog::segment_path]). Callers pass the file stem so a segment's auxiliary
+/// files (`-{index}.arrows` cache, `.recovery`/`.recovered`) — which share the
+/// base path with one extension — parse to the same locator as the main file.
+///
+/// The index is the final dash-delimited, purely numeric token, so partition
+/// names containing dashes parse correctly. Returns `None` for names that are
+/// not segment files (foreign files), which the high-water filter then leaves
+/// reported as genuine orphans.
+fn parse_segment_locator(topic: &str, file_stem: &str) -> Option<(String, SegmentIndex)> {
+    let rest = file_stem.strip_prefix(topic)?.strip_prefix('-')?;
+    let (partition, index) = rest.rsplit_once('-')?;
+    if partition.is_empty() {
+        return None;
+    }
+    let index: usize = index.parse().ok()?;
+    Some((partition.to_string(), SegmentIndex(index)))
 }
 
 /// Configuration for the reconciliation job
@@ -331,6 +351,13 @@ pub struct ReconcileReport {
     /// on reports that were never published through the loop (e.g. a report read
     /// directly off a [ReconcileJob] mid-pass, or constructed in tests).
     pub last_pass_completed_at: Option<DateTime<Utc>>,
+    /// How many untracked segment files the high-water filter suppressed because
+    /// their index sits *above* the highest segment present in the partition's
+    /// manifest snapshot — the active tail, or a just-rolled segment whose row
+    /// has not been committed yet (rows are written by an async commit thread
+    /// after the file appears on disk). These are in-flight, not orphans:
+    /// counted here for visibility rather than reported as untracked.
+    pub active_tail_skipped: usize,
 }
 
 impl ReconcileReport {
@@ -643,9 +670,52 @@ impl ReconcileJob {
             partition_files.len()
         );
 
+        // Highest segment index present in the tracked (manifest) snapshot per
+        // partition. The high-water filter judges untracked segment files
+        // against this: a file whose index exceeds its partition's max is one
+        // that rolled after the snapshot, or whose manifest row has not been
+        // committed yet — the in-flight active tail, not an orphan. Deriving the
+        // bound from `tracked_files` (rather than re-reading `sealed_ix`) keeps
+        // it consistent with the very set we are diffing against, so a segment
+        // that sealed mid-pass cannot fall through the gap between the two.
+        let mut max_tracked: HashMap<String, SegmentIndex> = HashMap::new();
+        for path in &tracked_files {
+            if let Some((partition, index)) = path
+                .file_stem()
+                .and_then(|n| n.to_str())
+                .and_then(|stem| parse_segment_locator(topic_name, stem))
+            {
+                max_tracked
+                    .entry(partition)
+                    .and_modify(|m| *m = (*m).max(index))
+                    .or_insert(index);
+            }
+        }
+
         for file_path in partition_files {
             debug!("Checking file: {:?}", file_path);
             if !tracked_files.contains(&file_path) {
+                // High-water filter: suppress in-flight segment files (and their
+                // auxiliary files) sitting above the partition's highest tracked
+                // segment. A partition with no tracked segments has no ceiling,
+                // so any of its segment files is in-flight. Files that do not
+                // parse as a segment (foreign files) are always reported.
+                if let Some((partition, index)) = file_path
+                    .file_stem()
+                    .and_then(|n| n.to_str())
+                    .and_then(|stem| parse_segment_locator(topic_name, stem))
+                {
+                    let in_flight = max_tracked.get(&partition).is_none_or(|max| index > *max);
+                    if in_flight {
+                        debug!(
+                            "Skipping in-flight segment file above tracked max: {:?}",
+                            file_path
+                        );
+                        self.state.report.active_tail_skipped += 1;
+                        continue;
+                    }
+                }
+
                 warn!("Untracked file in topic {:?}: {:?}", topic_name, file_path);
                 // Add the untracked path to our stats
                 let file_size = fs::metadata(&file_path)
@@ -1260,6 +1330,87 @@ mod tests {
                 assert_eq!(paths[0], orphan_file_path);
             }
             PathStats::Counter(_) => panic!("Expected Paths variant when track_files is enabled"),
+        }
+
+        Ok(())
+    }
+
+    /// The high-water filter suppresses an in-flight segment file — one whose
+    /// index sits above the partition's highest tracked (manifest) segment, as a
+    /// just-rolled-but-uncommitted segment does — counting it in
+    /// `active_tail_skipped` rather than reporting it as untracked. A genuinely
+    /// foreign file in the same directory is still reported.
+    #[test_log::test(tokio::test)]
+    async fn test_high_water_skips_inflight_segment_file() -> Result<()> {
+        use tokio::io::AsyncWriteExt;
+
+        // Roll after 2 rows so segment 0 seals and segment 1 becomes the tail.
+        let (_tmpdir, catalog) = create_test_catalog_rolling(2).await;
+        let topic_name = "high-water";
+        let partition_name = "p0";
+
+        let topic = catalog.get_topic(topic_name).await;
+        topic
+            .extend_records(partition_name, &test_records(&["a", "b", "c"]))
+            .await?;
+        topic
+            .extend_records(partition_name, &test_records(&["d", "e", "f"]))
+            .await?;
+        drop(topic);
+        catalog.checkpoint().await;
+        catalog
+            .get_topic(topic_name)
+            .await
+            .ensure_index(partition_name, RecordIndex(6))
+            .await?;
+        catalog.checkpoint().await;
+
+        // Segments 0 and 1 are tracked, so the partition's high-water mark is 1.
+        let partition_id = PartitionId::new(topic_name, partition_name);
+        let topic_path = Topic::partition_root(catalog.topic_root(), topic_name);
+        let slog_name = Partition::slog_name(&partition_id);
+
+        // An in-flight segment file well above the tracked max, with no manifest
+        // row: exactly what a just-rolled-but-uncommitted segment looks like on
+        // disk before the async commit thread writes its row.
+        let inflight = Slog::segment_path(&topic_path, &slog_name, SegmentIndex(5));
+        {
+            let mut f = fs::File::create(&inflight).await?;
+            f.write_all(b"in-flight segment, no manifest row yet")
+                .await?;
+            f.flush().await?;
+        }
+        // A genuinely foreign file that does not parse as a segment: the
+        // high-water filter must not touch it, so it stays reported as untracked.
+        let foreign = topic_path.join("not-a-segment.tmp");
+        {
+            let mut f = fs::File::create(&foreign).await?;
+            f.write_all(b"foreign").await?;
+            f.flush().await?;
+        }
+
+        let config = ReconcileConfig {
+            track_files: true,
+            ..Default::default()
+        };
+        let mut reconciler = ReconcileJob::with_config(catalog.clone(), config);
+        assert!(reconciler.run(Some(100)).await?);
+        let report = reconciler.report();
+
+        // The above-watermark segment file is suppressed and counted; only the
+        // foreign file remains as a genuine untracked orphan.
+        assert!(
+            report.active_tail_skipped >= 1,
+            "in-flight segment file above the watermark must be skipped, not reported"
+        );
+        assert_eq!(
+            report.sealed.untracked_files.len(),
+            1,
+            "only the foreign file should remain untracked"
+        );
+        match &report.sealed.untracked_files.paths {
+            PathStats::Paths(paths) => assert_eq!(paths[0], foreign),
+            PathStats::Counter(_) => panic!("expected Paths variant with track_files"),
         }
 
         Ok(())

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -554,6 +554,7 @@ async fn get_info(
                     missing_files: sealed.missing_files.len(),
                     expected_size: sealed.expected_size.as_u64() as usize,
                     actual_size: sealed.actual_size.as_u64() as usize,
+                    active_tail_skipped: report.active_tail_skipped,
                 };
                 let active_segments = report
                     .active

--- a/server/tests/server.rs
+++ b/server/tests/server.rs
@@ -1070,6 +1070,7 @@ async fn info_endpoint() -> Result<()> {
     assert!(retention_stats["missing_files"].is_number());
     assert!(retention_stats["expected_size"].is_number());
     assert!(retention_stats["actual_size"].is_number());
+    assert!(retention_stats["active_tail_skipped"].is_number());
 
     // The active-segment bucket is part of the wire format. The freshly written
     // partitions have not rolled, so their active tails should be reported here.

--- a/server/tests/server.rs
+++ b/server/tests/server.rs
@@ -1350,3 +1350,144 @@ async fn reconcile_loop_cancels_on_shutdown() -> Result<()> {
 
     Ok(())
 }
+
+/// Integration soak/torture test for continuous reconciliation racing writes
+/// and retention. Three things hammer the same partitions at once: a writer
+/// flooding randomised batches over HTTP, retention retiring the oldest sealed
+/// segment on nearly every roll (tiny `max_segment_count`), and the reconcile
+/// loop sweeping back-to-back with fixes enabled. Segments seal every few rows
+/// (`max_rows`), so there is almost always a just-rolled segment whose manifest
+/// row has not committed yet — the case the high-water filter must suppress.
+///
+/// Reconcile only fixes manifest size entries and never removes files, so the
+/// rare retention races (a missing/orphan diff for a segment retired mid-pass)
+/// are harmless, transient, self-healing noise; we deliberately do not assert
+/// the diff buckets are empty mid-storm. What we assert is:
+///
+/// - Liveness: the loop survives the storm and keeps publishing fresh passes.
+/// - Coverage: `active_tail_skipped > 0` is observed, proving the high-water
+///   filter actually fires under real concurrency. Unlike a retention race this
+///   is reliable, because an in-flight segment is essentially always present
+///   under load.
+/// - Convergence: once writes quiesce, a fresh pass reports fully clean (no
+///   missing, untracked, or size mismatch), proving the filter did not mask a
+///   persistent inconsistency.
+#[test_log::test(tokio::test)]
+async fn reconcile_torture_under_retention_churn() -> Result<()> {
+    let server = TestServer::localhost_with_config(PlateauConfig {
+        catalog: catalog::Config {
+            partition: partition::Config {
+                // Seal a segment every few rows so the sealed population churns.
+                roll: limit::Rolling {
+                    max_rows: 4,
+                    ..Default::default()
+                },
+                // Keep only a handful of sealed segments: retention retires the
+                // oldest on nearly every roll, racing the reconcile scan.
+                retain: limit::Retention {
+                    max_segment_count: Some(3),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..PlateauConfig::default()
+    })
+    .await?;
+
+    let client = Client::new();
+    let topic = random_topic();
+    let partitions = ["p0", "p1", "p2"];
+
+    // Reconcile continuously, fixes enabled, back-to-back fast passes with no
+    // idle gap so it sweeps as hard as possible against the writer.
+    let loop_handle = tokio::spawn(catalog::ReconcileJob::run_loop(
+        server.catalog.clone(),
+        catalog::ReconcileConfig {
+            track_files: true,
+            idle_ratio: 0.0,
+            pass_interval: Some(Duration::from_millis(1)),
+            fixes: [catalog::reconcile::ReconcileFix::UpdateManifestSizes]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        },
+    ));
+
+    // Deterministic xorshift so a failing run reproduces from the seed below.
+    let seed: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut rng = seed;
+    let mut next = || {
+        rng ^= rng << 13;
+        rng ^= rng >> 7;
+        rng ^= rng << 17;
+        rng
+    };
+
+    let mut max_active_tail_skipped = 0usize;
+    let mut saw_completed_pass = false;
+    const ROUNDS: usize = 400;
+    for round in 0..ROUNDS {
+        // Randomised batch size (1..=9 rows) across rotating partitions widens
+        // the timing window and varies segment sizes.
+        let count = 1 + (next() % 9) as usize;
+        let partition = partitions[round % partitions.len()];
+        repeat_append(
+            &client,
+            append_url(&server, &topic, partition).as_str(),
+            TEST_MESSAGE,
+            count,
+        )
+        .await;
+
+        // Periodically flush so segments seal durably and retention can act.
+        if round % 4 == 0 {
+            server.catalog.checkpoint().await;
+        }
+
+        // Sample the latest published report (lock-free, typed). The high-water
+        // filter should be suppressing in-flight segments throughout the storm.
+        if let Some(report) = server.catalog.latest_reconcile_report() {
+            saw_completed_pass = true;
+            max_active_tail_skipped = max_active_tail_skipped.max(report.active_tail_skipped);
+        }
+    }
+
+    tracing::info!(seed, max_active_tail_skipped, "torture writer finished");
+
+    // Liveness: the loop kept up and published at least one pass during the storm.
+    assert!(
+        saw_completed_pass,
+        "reconcile loop should publish at least one pass during the storm"
+    );
+    // Coverage: the high-water filter demonstrably fired under real concurrency.
+    assert!(
+        max_active_tail_skipped > 0,
+        "expected the high-water filter to suppress in-flight segments under churn; \
+         if this is flaky, the writer is not rolling fast enough"
+    );
+
+    // Quiesce: stop writing, flush, and wait for a strictly-newer pass over the
+    // settled catalog. With nothing racing and all rolls committed, that pass
+    // must be fully clean — no missing, untracked, or size-mismatch diffs.
+    server.catalog.checkpoint().await;
+    let before_ts = get_json(&client, &info_url(&server))
+        .await?
+        .get("last_reconcile_pass_completed_at")
+        .cloned()
+        .unwrap_or(json::Value::Null);
+    let clean = poll_info_until(&client, &info_url(&server), |info| {
+        let stats = &info["retention_stats"];
+        info["pending"] == json::json!(false)
+            && info["last_reconcile_pass_completed_at"] != before_ts
+            && stats["missing_files"] == json::json!(0)
+            && stats["untracked_files"] == json::json!(0)
+            && stats["size_mismatches"] == json::json!(0)
+    })
+    .await;
+    assert_eq!(clean["retention_stats"]["untracked_files"], json::json!(0));
+
+    loop_handle.abort();
+    Ok(())
+}

--- a/transport/src/lib.rs
+++ b/transport/src/lib.rs
@@ -491,6 +491,15 @@ pub struct ReconcileStats {
     pub missing_files: usize,
     pub expected_size: usize,
     pub actual_size: usize,
+    /// Count of untracked segment files the high-water filter suppressed because
+    /// they sit above their partition's highest committed segment — the active
+    /// tail or a just-rolled segment whose manifest row has not been written
+    /// yet. These are in-flight, not orphans; surfaced so a persistently nonzero
+    /// `untracked_files` can be told apart from normal write churn.
+    ///
+    /// Defaulted on deserialization so older clients and payloads remain valid.
+    #[serde(default)]
+    pub active_tail_skipped: usize,
 }
 
 /// Wire form of a reconciliation report for the active (writeable) tail segment


### PR DESCRIPTION
Summary via Claude:

## Background

Now that reconciliation runs continuously alongside writes and retention (#79, #81), its orphan sweep produces a persistent false positive. The sweep flags any on-disk file with no committed manifest row as untracked, but a just-rolled segment's file appears on disk before the async commit thread writes its manifest row. So under continuous writes there's almost always one in-flight segment showing up as a phantom untracked file (along with its -{index}.arrows/.recovery auxiliary files).

The sealed/active watermark (#77, #78) doesn't help here — it only buckets segments that already have a manifest row, so it never sees these uncommitted files. Reconcile never removes orphans (RemoveOrphans is still a TODO; the only mutating fix is the CAS UpdateManifestSizes), so this was harmless — but it left /info's untracked_files near-permanently nonzero, making it useless as a consistency signal under load.
Change

A high-water filter in the orphan sweep: suppress untracked segment files whose index sits above their partition's highest tracked (manifest) segment — the active tail and just-rolled, not-yet-committed segments — and count them in ReconcileReport::active_tail_skipped. Genuinely foreign files (names that don't parse as a segment) are untouched and still reported.

Two correctness details:

- The ceiling is derived from the tracked-file set itself, not a fresh sealed_ix read. This keeps it consistent with the very set being diffed: a segment that seals mid-pass is absent from the tracked snapshot, so judging it against a freshly-read (advanced) watermark would leave its file spuriously untracked.
- Files are matched by stem, so a segment's auxiliary files share their main file's locator and are suppressed together.

active_tail_skipped is surfaced on /info (serde-defaulted for wire compatibility) so an operator can distinguish normal in-flight churn from a real change in untracked_files.

## Tests

- Unit (test_high_water_skips_inflight_segment_file): an in-flight segment file above the watermark is suppressed and counted; a foreign file in the same directory is still reported.
- Soak (reconcile_torture_under_retention_churn): a real server driven by a seeded randomised HTTP writer + aggressive retention churn + the continuous reconcile loop. Asserts what's robustly true given reconcile is fix-only-never-remove: the loop survives the storm and keeps publishing (liveness); active_tail_skipped > 0 is observed (coverage — the filter fires under real concurrency); and once writes quiesce, a fresh pass reports fully clean (convergence). It deliberately does not assert empty diff buckets mid-storm — the rare retention-race diffs are harmless, transient, self-healing noise, not corruption.

## Scope notes

Report/observability only — no change to what reconcile fixes or removes.