### PR TITLE
ci: use 4x16g-arm runner for arm64 build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,7 +97,7 @@ jobs:
 
   build-multi-arm64:
     runs-on:
-      - buildjet-4vcpu-ubuntu-2204-arm
+      - 4x16g-arm
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
The buildjet-4vcpu-ubuntu-2204-arm runner was removed ages ago.