### PR TITLE
Initialize sealed_ix watermark from manifest on partition attach

### DIFF
--- a/catalog/src/partition.rs
+++ b/catalog/src/partition.rs
@@ -111,7 +111,11 @@ impl Partition {
         let (commit_writer, commits) = watch::channel(record);
         let commit_manifest = manifest.clone();
         let commit_id = id.clone();
-        let (sealed_tx, sealed_ix) = watch::channel(None);
+        // All manifest segments up to and including the max are sealed on
+        // attach: find_starting_index always starts the new active segment at
+        // max+1, so the previous max is definitionally closed.
+        let initial_sealed = segment.prev();
+        let (sealed_tx, sealed_ix) = watch::channel(initial_sealed);
         tokio::spawn(async move {
             while let Some(r) = writes.recv().await {
                 trace!("{} checkpoint: {:?}", commit_id, &r);


### PR DESCRIPTION
sealed_ix was always initialized to None, so reconcile treated every manifest segment as active (never sealed) until a roll happened in the current process lifetime. On a freshly restarted server, this meant UpdateManifestSizes never fired — all size mismatches were silently skipped.

find_starting_index always advances to max_manifest_ix+1 on attach, so every manifest segment including the max is definitionally sealed. Initialize sealed_ix to segment.prev() (= max_manifest_ix, or None for a fresh partition) so reconcile can fix stale sizes on the first pass after startup.