### PR TITLE
Include cache size in manifest segment size

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -154,11 +154,9 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
             while let Some((dn, d)) = rx.recv().await {
                 let elapsed = start.elapsed().as_secs();
                 total += dn;
-                let nps = if elapsed > 0 {
-                    ((total as u64) / elapsed).to_string()
-                } else {
-                    String::from("-")
-                };
+                let nps = (total as u64)
+                    .checked_div(elapsed)
+                    .map_or_else(|| String::from("-"), |v| v.to_string());
                 h.record(d.as_millis() as u64).unwrap();
                 let p50 = Duration::from_millis(h.value_at_percentile(50.));
                 let p90 = Duration::from_millis(h.value_at_percentile(90.));

--- a/catalog/src/partition.rs
+++ b/catalog/src/partition.rs
@@ -243,9 +243,9 @@ impl Partition {
         match order {
             Ordering::Forward => stored
                 .filter(move |data| future::ready(!cached_segments.contains(&data.index)))
-                .chain(stream::iter(cached.into_iter()))
+                .chain(stream::iter(cached))
                 .boxed(),
-            Ordering::Reverse => stream::iter(cached.into_iter())
+            Ordering::Reverse => stream::iter(cached)
                 .chain(
                     stored
                         .filter(move |data| future::ready(!cached_segments.contains(&data.index))),
@@ -315,7 +315,7 @@ impl Partition {
 
             let boolean_values: Vec<bool> = indices_array
                 .into_iter()
-                .zip(times_array.into_iter())
+                .zip(times_array)
                 .map(|(index, time)| {
                     index.is_some_and(|idx| idx >= (start.0 as i32))
                         && time.is_some_and(|t| times.contains(&parse_time(t)))
@@ -340,7 +340,7 @@ impl Partition {
             .await
             .iter()
             .map(|data| data.records.clone())
-            .chain(stored.into_iter())
+            .chain(stored)
             .reduce(merge_ranges)
     }
 

--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -1002,15 +1002,13 @@ impl ReconcileJob {
         {
             if part_path.exists() {
                 tracked_files.insert(part_path.clone());
-                if part_path != segment_file.cache_path() {
-                    match fs::metadata(&part_path).await {
-                        Ok(metadata) => {
-                            total_actual_size += metadata.len() as usize;
-                            debug!("Part {:?} size: {}", part_path, metadata.len());
-                        }
-                        Err(e) => {
-                            warn!("Error getting metadata for part {:?}: {:?}", part_path, e);
-                        }
+                match fs::metadata(&part_path).await {
+                    Ok(metadata) => {
+                        total_actual_size += metadata.len() as usize;
+                        debug!("Part {:?} size: {}", part_path, metadata.len());
+                    }
+                    Err(e) => {
+                        warn!("Error getting metadata for part {:?}: {:?}", part_path, e);
                     }
                 }
             } else {

--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -720,8 +720,7 @@ impl ReconcileJob {
                 // Add the untracked path to our stats
                 let file_size = fs::metadata(&file_path)
                     .await
-                    .map(|m| m.len() as usize)
-                    .unwrap_or(0);
+                    .map_or(0, |m| m.len() as usize);
                 self.state
                     .report
                     .sealed

--- a/catalog/src/topic.rs
+++ b/catalog/src/topic.rs
@@ -123,7 +123,7 @@ impl Topic {
             })
             .flat_map(|(name, p)| {
                 f(p).into_stream()
-                    .flat_map(|v| stream::iter(v.into_iter()))
+                    .flat_map(stream::iter)
                     .map(move |v| (name.clone(), v))
             })
             .collect()

--- a/client/src/replicate.rs
+++ b/client/src/replicate.rs
@@ -269,12 +269,12 @@ impl ReplicationWorker {
 
         let hosts_ref = &hosts;
 
-        let partitions = stream::iter(replicate.partitions.into_iter())
+        let partitions = stream::iter(replicate.partitions)
             .flat_map(move |part| stream::once(part.into_job(hosts_ref)))
             .try_collect()
             .await?;
 
-        let topics = stream::iter(replicate.topics.into_iter())
+        let topics = stream::iter(replicate.topics)
             .flat_map(move |topic| stream::once(topic.into_job(hosts_ref)))
             .try_collect()
             .await?;

--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -223,14 +223,12 @@ impl Segment {
     /// Return an estimate of the on-disk size of the corresponding file(s),
     /// including the active chunk cache if present.
     pub fn size_estimate(&self) -> Result<usize> {
-        let main_size = fs::metadata(&self.path).map(|p| p.len()).unwrap_or(0);
+        let main_size = fs::metadata(&self.path).map_or(0, |p| p.len());
         let part_size: u64 = self
             .parts()
-            .map(|part| fs::metadata(part).map(|p| p.len()).unwrap_or(0))
+            .map(|part| fs::metadata(part).map_or(0, |p| p.len()))
             .sum();
-        let cache_size = fs::metadata(self.cache_path())
-            .map(|p| p.len())
-            .unwrap_or(0);
+        let cache_size = fs::metadata(self.cache_path()).map_or(0, |p| p.len());
         Ok(usize::try_from(main_size + part_size + cache_size)?)
     }
 }

--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -221,14 +221,15 @@ impl Segment {
     }
 
     /// Return an estimate of the on-disk size of the corresponding file(s),
-    /// excluding the active chunk cache.
+    /// including the active chunk cache if present.
     pub fn size_estimate(&self) -> Result<usize> {
         let main_size = fs::metadata(&self.path).map(|p| p.len()).unwrap_or(0);
         let part_size: u64 = self
             .parts()
             .map(|part| fs::metadata(part).map(|p| p.len()).unwrap_or(0))
             .sum();
-        Ok(usize::try_from(main_size + part_size)?)
+        let cache_size = fs::metadata(self.cache_path()).map(|p| p.len()).unwrap_or(0);
+        Ok(usize::try_from(main_size + part_size + cache_size)?)
     }
 }
 
@@ -373,9 +374,7 @@ impl Writer {
 
     /// Return an estimate of the on-disk size of the corresponding file(s).
     pub fn size_estimate(&self) -> Result<usize> {
-        let segment_size = self.segment.size_estimate()?;
-        let cache_size = self.cache.size() as usize;
-        Ok(segment_size + cache_size)
+        self.segment.size_estimate()
     }
 
     pub fn close(self) -> Result<usize> {

--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -228,7 +228,9 @@ impl Segment {
             .parts()
             .map(|part| fs::metadata(part).map(|p| p.len()).unwrap_or(0))
             .sum();
-        let cache_size = fs::metadata(self.cache_path()).map(|p| p.len()).unwrap_or(0);
+        let cache_size = fs::metadata(self.cache_path())
+            .map(|p| p.len())
+            .unwrap_or(0);
         Ok(usize::try_from(main_size + part_size + cache_size)?)
     }
 }

--- a/data/src/segment/cache.rs
+++ b/data/src/segment/cache.rs
@@ -82,6 +82,7 @@ impl ActiveChunk {
         Ok(())
     }
 
+    #[expect(dead_code)]
     pub fn size(&self) -> u64 {
         self.writer.as_ref().map_or(0, |w| w.size())
     }

--- a/data/src/segment/cache.rs
+++ b/data/src/segment/cache.rs
@@ -151,7 +151,7 @@ impl Writer {
     }
 
     pub(super) fn size(&self) -> u64 {
-        fs::metadata(&self.path).map(|p| p.len()).unwrap_or(0)
+        fs::metadata(&self.path).map_or(0, |p| p.len())
     }
 }
 

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -192,9 +192,7 @@ async fn healthcheck(
     State(AppState(catalog, config)): State<AppState>,
 ) -> Result<Response<serde_json::Value>, ErrorReply> {
     let duration = SystemTime::now().duration_since(catalog.last_checkpoint().await);
-    let healthy = duration
-        .map(|d| d < config.catalog.checkpoint_interval * 10)
-        .unwrap_or(true);
+    let healthy = duration.map_or(true, |d| d < config.catalog.checkpoint_interval * 10);
     if healthy {
         Ok(Response::ok(json!({"ok": "true"})))
     } else {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -103,7 +103,7 @@ pub async fn task_from_catalog_config(
             tasks.push(Box::pin(replication::run(replicate, addr)));
         }
 
-        future::select_all(tasks.into_iter()).await;
+        future::select_all(tasks).await;
     }
 
     tracing::info!("shutting down");


### PR DESCRIPTION
The cache is "ephemeral" yes, but there are situations where it actually survives and is e.g. used in the recovery process. It should not be ignored; until it is physically removed from disk, it must be included in the size of its associated segment.