### PR TITLE
ci: build ARM image on GitHub-hosted ubuntu-24.04-arm instead of BuildJet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,7 +97,7 @@ jobs:
 
   build-multi-arm64:
     runs-on:
-      - buildjet-4vcpu-ubuntu-2204-arm
+      - ubuntu-24.04-arm
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
## Problem

The ARM runner needs to be updated; ARM jobs were hanging.

## Fix

```diff
   build-multi-arm64:
     runs-on:
-      - buildjet-4vcpu-ubuntu-2204-arm
+      - ubuntu-24.04-arm
```

## Verification
- The CI run on this PR should show `build-multi-arm64` picking up a hosted ARM runner and building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)