### PR TITLE
Convert tracing calls to structured fields

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -61,7 +61,7 @@ impl Worker {
             let (dn, status) = self.task.run(&self.config).await;
             let dt = start.elapsed();
             total += dn;
-            trace!("{}", status);
+            trace!(%status);
             self.status.send(status).unwrap();
             self.stats.send((dn, dt)).await.unwrap();
             if self.delay > dt {
@@ -103,7 +103,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
 
     let mut rng = rand::thread_rng();
     let seed = rng.next_u64();
-    debug!("seed: {}", seed);
+    debug!(%seed);
     let mut rng = StdRng::seed_from_u64(seed);
     tasks.shuffle(&mut rng);
 
@@ -178,11 +178,11 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
     let start = Instant::now();
     let mut strings = vec![];
     while start.elapsed() < test_duration {
-        debug!("{:->80}", "");
+        debug!("--------------------------------------------------------------------------------");
         let mut update_strings: Vec<_> = updates.iter_mut().map(|up| up.borrow().clone()).collect();
         update_strings.sort();
         for up in update_strings {
-            debug!("{}", up);
+            debug!(%up, "worker status");
         }
 
         strings = stat_updates
@@ -191,7 +191,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
             .collect();
         strings.sort();
         for up in &strings {
-            debug!("{}", up);
+            debug!(%up, "stats update");
         }
         tokio::time::sleep(Duration::from_secs(10)).await;
     }
@@ -203,7 +203,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
 
     for (name, handle) in handles {
         let value = handle.await.unwrap();
-        debug!("{}: {}", name, value);
+        debug!(worker = %name, total = %value, "worker finished");
     }
 
     let start = Instant::now();
@@ -213,9 +213,9 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
         plateau_server.await.unwrap(),
         "plateau failed to shutdown cleanly"
     );
-    info!("plateau shut down in {:?}", start.elapsed());
+    info!(elapsed = ?start.elapsed(), "plateau shut down");
 
     for up in strings {
-        info!("{}", up);
+        info!(%up, "stats update");
     }
 }

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -61,7 +61,7 @@ impl Worker {
             let (dn, status) = self.task.run(&self.config).await;
             let dt = start.elapsed();
             total += dn;
-            trace!(%status);
+            trace!(status);
             self.status.send(status).unwrap();
             self.stats.send((dn, dt)).await.unwrap();
             if self.delay > dt {
@@ -103,7 +103,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
 
     let mut rng = rand::thread_rng();
     let seed = rng.next_u64();
-    debug!(%seed);
+    debug!(seed);
     let mut rng = StdRng::seed_from_u64(seed);
     tasks.shuffle(&mut rng);
 
@@ -182,7 +182,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
         let mut update_strings: Vec<_> = updates.iter_mut().map(|up| up.borrow().clone()).collect();
         update_strings.sort();
         for up in update_strings {
-            debug!(%up, "worker status");
+            debug!(up, "worker status");
         }
 
         strings = stat_updates
@@ -191,7 +191,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
             .collect();
         strings.sort();
         for up in &strings {
-            debug!(%up, "stats update");
+            debug!(up, "stats update");
         }
         tokio::time::sleep(Duration::from_secs(10)).await;
     }
@@ -203,7 +203,7 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
 
     for (name, handle) in handles {
         let value = handle.await.unwrap();
-        debug!(worker = %name, total = %value, "worker finished");
+        debug!(worker = name, total = value, "worker finished");
     }
 
     let start = Instant::now();
@@ -216,6 +216,6 @@ pub async fn run(mut tasks: Vec<Box<dyn TaskBuilder>>, test_duration: Duration) 
     info!(elapsed = ?start.elapsed(), "plateau shut down");
 
     for up in strings {
-        info!(%up, "stats update");
+        info!(up, "stats update");
     }
 }

--- a/bench/src/load.rs
+++ b/bench/src/load.rs
@@ -169,9 +169,9 @@ mod test {
         for _ in 0..1 {
             sampler.set_len(1);
             let data = sampler.generate(&mut random);
-            trace!("data: {:?}", data);
+            trace!(?data, "generated data");
         }
-        debug!("elapsed: {:?}", now.elapsed());
+        debug!(elapsed = ?now.elapsed(), "sampling complete");
 
         Ok(())
     }

--- a/bench/src/write.rs
+++ b/bench/src/write.rs
@@ -117,7 +117,7 @@ impl Task for Writer {
             self.count += rows;
             (rows, (ok.span.start..ok.span.end))
         } else {
-            warn!(topic = %self.topic, partition = %self.partition, "rate limited");
+            warn!(topic = self.topic, partition = self.partition, "rate limited");
             (0, 0..0)
         };
 

--- a/bench/src/write.rs
+++ b/bench/src/write.rs
@@ -99,7 +99,7 @@ impl Task for Writer {
     async fn run(&mut self, config: &Config) -> (usize, String) {
         let start = Instant::now();
         let multi = self.sample_rx.recv().await.unwrap();
-        trace!("{:?} {:?}", start.elapsed(), multi);
+        trace!(elapsed = ?start.elapsed(), ?multi, "received sample");
 
         let r = config
             .client
@@ -117,7 +117,7 @@ impl Task for Writer {
             self.count += rows;
             (rows, (ok.span.start..ok.span.end))
         } else {
-            warn!("{}/{} rate limited", self.topic, self.partition);
+            warn!(topic = %self.topic, partition = %self.partition, "rate limited");
             (0, 0..0)
         };
 

--- a/bench/src/write.rs
+++ b/bench/src/write.rs
@@ -117,7 +117,11 @@ impl Task for Writer {
             self.count += rows;
             (rows, (ok.span.start..ok.span.end))
         } else {
-            warn!(topic = self.topic, partition = self.partition, "rate limited");
+            warn!(
+                topic = self.topic,
+                partition = self.partition,
+                "rate limited"
+            );
             (0, 0..0)
         };
 

--- a/catalog/src/catalog.rs
+++ b/catalog/src/catalog.rs
@@ -315,7 +315,7 @@ impl Catalog {
             info!(
                 open = topics.len(),
                 max_open = self.config.max_open_topics,
-                %to_drop,
+                to_drop,
                 "open topic limit hit, dropping topic"
             );
 
@@ -347,14 +347,14 @@ impl Catalog {
 
             // XXX - these errors should never happen as we hold the lock and just iterated above
             let Some(topic) = topics.get(&topic_name) else {
-                error!(%topic_name, "invalid topic");
+                error!(topic_name, "invalid topic");
                 continue;
             };
 
             let age = Utc::now().signed_duration_since(time).to_std();
             info!(
-                %topic_name,
-                %partition_name,
+                topic_name,
+                partition_name,
                 ?age,
                 bytes,
                 max_bytes,
@@ -363,7 +363,7 @@ impl Catalog {
                 "closing partition"
             );
             let Some(data) = topic.close_partition(&partition_name).await else {
-                error!(%partition_name, "invalid partition");
+                error!(partition_name, "invalid partition");
                 continue;
             };
 
@@ -448,7 +448,7 @@ impl Catalog {
             Err(read) => {
                 drop(read);
                 let mut write = self.state.write().await;
-                info!(%name, "creating new topic");
+                info!(name, "creating new topic");
                 let topic = Topic::attach(
                     self.topic_root.clone(),
                     self.manifest.clone(),
@@ -948,7 +948,7 @@ mod test {
 
         for (ix, record) in records.iter().enumerate() {
             let name = format!("topic-{}", ix % 3);
-            trace!(%name, record_ix = ix / 3, "checking record");
+            trace!(name, record_ix = ix / 3, "checking record");
             {
                 let topic = catalog.get_topic(&name).await;
                 assert_eq!(

--- a/catalog/src/catalog.rs
+++ b/catalog/src/catalog.rs
@@ -185,7 +185,7 @@ impl Catalog {
             let dst: PathBuf = topic_root.join(&topic);
 
             if src.exists() {
-                info!("migrating {src:?} to {dst:?}");
+                info!(?src, ?dst, "migrating");
                 std::fs::rename(src, dst)?;
             }
         }
@@ -208,11 +208,12 @@ impl Catalog {
         if let Ok(duration) = end.duration_since(start) {
             if duration > self.config.checkpoint_interval {
                 warn!(
-                    "full catalog checkpoint took {:?} (longer than interval ({:?})!)",
-                    duration, self.config.checkpoint_interval
+                    ?duration,
+                    interval = ?self.config.checkpoint_interval,
+                    "full catalog checkpoint took longer than interval"
                 );
             } else {
-                trace!("finished full catalog checkpoint in {:?}", duration);
+                trace!(?duration, "finished full catalog checkpoint");
             }
             gauge!("catalog_checkpoint_ms",).set((duration.as_micros() as f64) / 1000.0);
         } else {
@@ -261,7 +262,7 @@ impl Catalog {
             return;
         };
 
-        info!("startup reclaim: removing oldest segment {:?}", oldest);
+        info!(?oldest, "startup reclaim: removing oldest segment");
         let topic = self.get_topic(oldest.topic()).await;
         let partition = topic.get_partition(oldest.partition()).await;
         partition.reclaim_oldest().await;
@@ -312,10 +313,10 @@ impl Catalog {
             };
 
             info!(
-                "open topic limit hit ({} > {}), dropping \"{}\"",
-                topics.len(),
-                self.config.max_open_topics,
-                to_drop
+                open = topics.len(),
+                max_open = self.config.max_open_topics,
+                %to_drop,
+                "open topic limit hit, dropping topic"
             );
 
             if let Some(topic) = topics.remove(&to_drop) {
@@ -346,18 +347,23 @@ impl Catalog {
 
             // XXX - these errors should never happen as we hold the lock and just iterated above
             let Some(topic) = topics.get(&topic_name) else {
-                error!("invalid topic {topic_name}");
+                error!(%topic_name, "invalid topic");
                 continue;
             };
 
             let age = Utc::now().signed_duration_since(time).to_std();
             info!(
-                "closing {topic_name}/{partition_name} (age {age:?}, {bytes} > {max_bytes} bytes, \
-                 {} > {max_active} active)",
-                ages.len() + 1
+                %topic_name,
+                %partition_name,
+                ?age,
+                bytes,
+                max_bytes,
+                active = ages.len() + 1,
+                max_active,
+                "closing partition"
             );
             let Some(data) = topic.close_partition(&partition_name).await else {
-                error!("invalid partition {partition_name}");
+                error!(%partition_name, "invalid partition");
                 continue;
             };
 
@@ -409,12 +415,12 @@ impl Catalog {
     async fn over_retention_limit(&self) -> bool {
         let size = self.byte_size().await;
         let limit = self.total_byte_limit().await;
-        debug!(?limit, "catalog size: {}", size);
+        debug!(%size, %limit, "catalog size");
         gauge!("stored_size_bytes").set(size.as_u64() as f64);
         let over = size > limit;
 
         if over {
-            info!("over retention limit {} > {}", size, limit);
+            info!(%size, %limit, "over retention limit");
         }
 
         over
@@ -442,7 +448,7 @@ impl Catalog {
             Err(read) => {
                 drop(read);
                 let mut write = self.state.write().await;
-                info!("creating new topic: {}", name);
+                info!(%name, "creating new topic");
                 let topic = Topic::attach(
                     self.topic_root.clone(),
                     self.manifest.clone(),
@@ -493,9 +499,9 @@ impl Catalog {
             .await
         {
             error!(
-                "error while monitoring disk storage capacity for {}: {:?}",
-                std::fs::canonicalize(&self.root).unwrap().display(),
-                e
+                path = %std::fs::canonicalize(&self.root).unwrap().display(),
+                %e,
+                "error while monitoring disk storage capacity"
             );
             // we want to loop here; otherwise the select() in main exits early
             // this could allow the server to run without the disk watcher, but
@@ -530,7 +536,7 @@ impl Catalog {
     pub async fn close_arc(mut catalog: Arc<Self>) -> bool {
         let now = Instant::now();
         let secs = 30;
-        info!("waiting {secs}s for all pending operations to complete");
+        info!(secs, "waiting for all pending operations to complete");
         let mut exclusive = None;
         for _ in 0..secs {
             // gah, into_inner is 1.70 onward...
@@ -543,21 +549,21 @@ impl Catalog {
                     catalog = arc;
                 }
             }
-            trace!("outstanding: {}", Arc::strong_count(&catalog));
+            trace!(outstanding = Arc::strong_count(&catalog));
             time::sleep(Duration::from_secs(1)).await;
         }
 
         if let Some(exclusive) = exclusive {
-            info!("all pending operations completed in {:?}", now.elapsed());
+            info!(elapsed = ?now.elapsed(), "all pending operations completed");
             let now = Instant::now();
             info!("performing final checkpoint");
             exclusive.checkpoint().await;
-            info!("final checkpoint complete in {:?}", now.elapsed());
+            info!(elapsed = ?now.elapsed(), "final checkpoint complete");
 
             let now = Instant::now();
             info!("closing catalog");
             exclusive.close().await;
-            info!("catalog closed in {:?}", now.elapsed());
+            info!(elapsed = ?now.elapsed(), "catalog closed");
             true
         } else {
             warn!("operations still pending; could not close catalog");
@@ -942,7 +948,7 @@ mod test {
 
         for (ix, record) in records.iter().enumerate() {
             let name = format!("topic-{}", ix % 3);
-            trace!("{name} {}", ix / 3);
+            trace!(%name, record_ix = ix / 3, "checking record");
             {
                 let topic = catalog.get_topic(&name).await;
                 assert_eq!(

--- a/catalog/src/catalog.rs
+++ b/catalog/src/catalog.rs
@@ -500,7 +500,7 @@ impl Catalog {
         {
             error!(
                 path = %std::fs::canonicalize(&self.root).unwrap().display(),
-                %e,
+                ?e,
                 "error while monitoring disk storage capacity"
             );
             // we want to loop here; otherwise the select() in main exits early

--- a/catalog/src/manifest.rs
+++ b/catalog/src/manifest.rs
@@ -197,7 +197,7 @@ static MIGRATOR: Migrator = sqlx::migrate!();
 impl Manifest {
     pub async fn current_prior_attach(current: PathBuf, prior: PathBuf) -> anyhow::Result<Self> {
         if prior.exists() && !current.exists() {
-            info!("migrating {prior:?} to {current:?}");
+            info!(?prior, ?current, "migrating");
             copy_existing(&shm_path(&prior)?, &shm_path(&current)?)?;
             copy_existing(&wal_path(&prior)?, &wal_path(&current)?)?;
             std::fs::copy(&prior, &current)?;
@@ -244,7 +244,7 @@ impl Manifest {
 
     /// Upserts data for a segment with the given identifier.
     pub(crate) async fn update(&self, id: &PartitionId, data: &SegmentData) {
-        trace!("update {:?}: {:?}", id, data);
+        trace!(%id, ?data, "update");
         sqlx::query(
             "
             INSERT INTO segments(
@@ -488,7 +488,7 @@ impl Manifest {
 
     /// Remove the identified segment from the manifest.
     pub async fn remove_segment(&self, id: SegmentId<&PartitionId>) {
-        trace!("remove segment {:?}", id);
+        trace!(%id, "remove segment");
         sqlx::query(
             "
             DELETE FROM segments
@@ -555,7 +555,7 @@ impl Manifest {
             let path = transformed.as_deref().unwrap_or(path);
             path.metadata()
                 .map(|meta| meta.size())
-                .inspect_err(|e| error!("error getting size of {path:?}: {e:?}"))
+                .inspect_err(|e| error!(?path, error = ?e, "error getting size of path"))
                 .unwrap_or(0) as usize
         }
 

--- a/catalog/src/partition.rs
+++ b/catalog/src/partition.rs
@@ -131,7 +131,7 @@ impl Partition {
         let (sealed_tx, sealed_ix) = watch::channel(initial_sealed);
         tokio::spawn(async move {
             while let Some(r) = writes.recv().await {
-                trace!("{} checkpoint: {:?}", commit_id, &r);
+                trace!(%commit_id, checkpoint = ?&r, "checkpoint");
                 commit_manifest.update(&commit_id, &r.data).await;
                 // the manifest update above is now durable. if it sealed the
                 // segment, advance the watermark, holding it monotonic against
@@ -148,7 +148,7 @@ impl Partition {
                 // ok if no receivers, that means nothing is awaiting a commit
                 commit_writer.send(r.data.records.end).ok();
             }
-            trace!("{} exit", commit_id);
+            trace!(%commit_id, "exit");
             fin_tx.send(()).ok();
         });
 
@@ -186,9 +186,9 @@ impl Partition {
                 index = match data {
                     Some(data) if valid => Some((ix.next(), data.records.end)),
                     _ => {
-                        error!("bad {:?} file: {} catalog: {}", ix, valid, data.is_some());
+                        error!(?ix, valid, in_catalog = data.is_some(), "bad segment file");
                         if let Err(e) = segment.destroy() {
-                            error!("error destroying {:?}: {}", ix, e);
+                            error!(?ix, %e, "error destroying segment");
                         }
                         manifest.remove_segment(ix.to_id(id)).await;
                         current = ix.prev();
@@ -350,7 +350,7 @@ impl Partition {
     pub async fn readable_ids(&self) -> Option<Range<RecordIndex>> {
         let read = self.state.read().await;
         let stored = self.manifest.get_partition_range(&self.id).await;
-        debug!("stored: {:?}", stored);
+        debug!(?stored);
 
         read.messages
             .cached_segment_data()
@@ -376,7 +376,7 @@ impl Partition {
         )
         .set(size as f64);
         if size > (retain.max_bytes.as_u64() as usize) {
-            info!("over limit {}: current size is {}", self.id, size);
+            info!(id = %self.id, size, "over limit");
             return true;
         }
 
@@ -401,7 +401,7 @@ impl Partition {
             )
             .set(segments as f64);
             if segments > count {
-                info!("over limit {}: {:?}..={:?}", self.id, min, max);
+                info!(id = %self.id, ?min, ?max, "over limit");
                 return true;
             }
         }
@@ -491,9 +491,9 @@ impl State {
 
             if *self.commits.borrow() != RecordIndex(0) {
                 warn!(
-                    "{}: schema change after {:?}",
-                    partition.id,
-                    *self.commits.borrow()
+                    id = %partition.id,
+                    commits = ?*self.commits.borrow(),
+                    "schema change after commits"
                 );
             }
 
@@ -506,9 +506,9 @@ impl State {
                 let dt = Instant::now() - self.last_roll;
                 if dt > d {
                     info!(
-                        "rolling {}: last roll was {}s ago",
-                        partition.id,
-                        dt.as_secs()
+                        id = %partition.id,
+                        last_roll_secs = dt.as_secs(),
+                        "rolling: last roll too long ago"
                     );
                     return self.roll(partition).await;
                 }
@@ -517,8 +517,10 @@ impl State {
             let current_len = data.records.end.0 - data.records.start.0;
             if current_len > roll.max_rows {
                 info!(
-                    "rolling {}: length {} > {}",
-                    partition.id, current_len, roll.max_rows
+                    id = %partition.id,
+                    current_len,
+                    max_rows = roll.max_rows,
+                    "rolling: length over limit"
                 );
                 return self.roll(partition).await;
             }
@@ -526,8 +528,10 @@ impl State {
             let max_bytes = roll.max_bytes.as_u64() as usize;
             if data.size > max_bytes {
                 info!(
-                    "rolling {}: current size {} > {}",
-                    partition.id, data.size, max_bytes
+                    id = %partition.id,
+                    size = data.size,
+                    max_bytes,
+                    "rolling: current size over limit"
                 );
                 return self.roll(partition).await;
             }
@@ -642,7 +646,7 @@ impl State {
                         .await;
                 }
             }
-            info!("retain {}: destroyed {:?}", partition.id, ix);
+            info!(id = %partition.id, ?ix, "retain: destroyed segment");
             counter!(
                 "partition_segments_destroyed",
                 "topic" => String::from(partition.id.topic()),
@@ -653,11 +657,11 @@ impl State {
     }
 
     async fn wait_for_record(&mut self, target: RecordIndex) {
-        trace!("waiting for commit including {:?}", target);
+        trace!(?target, "waiting for commit including");
         while *self.commits.borrow() < target {
             self.commits.changed().await.expect("commit watcher ended");
         }
-        trace!("notified of commit including {:?}", target);
+        trace!(?target, "notified of commit including");
     }
 
     #[cfg(test)]
@@ -671,7 +675,7 @@ impl State {
     pub(crate) async fn close(self) {
         self.messages.close().await;
         if let Err(e) = self.fin.await {
-            error!("error closing: {:?}", e)
+            error!(error = ?e, "error closing")
         }
     }
 }
@@ -1510,18 +1514,18 @@ pub mod test {
 
         // first, corrupt the last file.
         let segment = Slog::segment_from_name(root.as_path(), &slog_name, last);
-        debug!("corrupting {last:?}");
+        debug!(?last, "corrupting");
         let f = fs::File::options().write(true).open(segment.path())?;
         f.set_len(16)?;
 
         // delete the next data entry from the manifest
         let ix = last.prev().unwrap();
-        debug!("removing manifest entry for {ix:?}");
+        debug!(?ix, "removing manifest entry");
         manifest.remove_segment(ix.to_id(&spec.1)).await;
 
         // delete the next file entirely
         let segment = Slog::segment_from_name(root.as_path(), &slog_name, ix.prev().unwrap());
-        debug!("deleting {:?}", ix.prev().unwrap());
+        debug!(ix = ?ix.prev().unwrap(), "deleting");
         segment.destroy()?;
 
         records.truncate(records.len() - 3 * 3);

--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -762,7 +762,12 @@ impl ReconcileJob {
         let partition_id = PartitionId::new(topic_name, partition_name);
         let topic_path = Topic::partition_root(root, topic_name);
 
-        debug!(topic_name, partition_name, ?topic_path, "processing partition");
+        debug!(
+            topic_name,
+            partition_name,
+            ?topic_path,
+            "processing partition"
+        );
 
         // Classify this partition's segments once for the whole pass, *without*
         // loading it into memory. A partition that is not resident is quiescent:
@@ -976,12 +981,7 @@ impl ReconcileJob {
         let delta = disk_size as i64 - manifest_size as i64;
         debug!(
             segment_file_name,
-            topic_name,
-            partition_name,
-            manifest_size,
-            disk_size,
-            delta,
-            "active segment"
+            topic_name, partition_name, manifest_size, disk_size, delta, "active segment"
         );
 
         self.state.report.active.push(ActiveSegmentReport {
@@ -1009,7 +1009,11 @@ impl ReconcileJob {
         match fs::metadata(segment_path).await {
             Ok(metadata) => {
                 total_actual_size += metadata.len() as usize;
-                debug!(segment_file_name, size = metadata.len(), "segment file size");
+                debug!(
+                    segment_file_name,
+                    size = metadata.len(),
+                    "segment file size"
+                );
             }
             Err(e) => {
                 warn!(segment_file_name, error = ?e, "error getting metadata for segment");

--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -620,7 +620,7 @@ impl ReconcileJob {
         // Get the current topic name
         let topic_name = topics[current_topic_index].clone();
 
-        debug!(%topic_name, "reconciling topic");
+        debug!(topic_name, "reconciling topic");
 
         // Get all partitions for this topic
         let partitions = self.catalog.manifest().get_partitions(&topic_name).await;
@@ -645,7 +645,7 @@ impl ReconcileJob {
 
         // Process the current partition
         let partition_name = partitions[current_partition_index].clone();
-        debug!(%topic_name, %partition_name, "reconciling partition");
+        debug!(topic_name, partition_name, "reconciling partition");
 
         // Process this partition
         let partition_segments = self
@@ -733,7 +733,7 @@ impl ReconcileJob {
                     }
                 }
 
-                warn!(%topic_name, ?file_path, "untracked file in topic");
+                warn!(topic_name, ?file_path, "untracked file in topic");
                 // Add the untracked path to our stats
                 let file_size = fs::metadata(&file_path)
                     .await
@@ -762,7 +762,7 @@ impl ReconcileJob {
         let partition_id = PartitionId::new(topic_name, partition_name);
         let topic_path = Topic::partition_root(root, topic_name);
 
-        debug!(%topic_name, %partition_name, ?topic_path, "processing partition");
+        debug!(topic_name, partition_name, ?topic_path, "processing partition");
 
         // Classify this partition's segments once for the whole pass, *without*
         // loading it into memory. A partition that is not resident is quiescent:
@@ -815,7 +815,7 @@ impl ReconcileJob {
             let segment_file_name = format!("{}-{}", slog_name, segment.index.0);
             let segment_path = Slog::segment_path(&topic_path, &slog_name, segment.index);
 
-            debug!(%slog_name, ?segment_path, "checking segment file");
+            debug!(slog_name, ?segment_path, "checking segment file");
 
             // Mark this file as tracked regardless of bucket so the orphan
             // detection phase does not false-positive on active segment files.
@@ -893,7 +893,7 @@ impl ReconcileJob {
         );
         if total_actual_size.abs_diff(segment.size) > 0 {
             warn!(
-                %segment_file_name,
+                segment_file_name,
                 %expected_size,
                 %actual_size,
                 "size mismatch for segment"
@@ -930,17 +930,17 @@ impl ReconcileJob {
                     )
                     .await;
                 if applied {
-                    info!(%segment_file_name, "fixed size mismatch for segment");
+                    info!(segment_file_name, "fixed size mismatch for segment");
                 } else {
                     info!(
-                        %segment_file_name,
+                        segment_file_name,
                         "skipped stale size fix for segment (concurrently removed or changed)"
                     );
                 }
             }
         } else {
             debug!(
-                %segment_file_name,
+                segment_file_name,
                 expected = segment.size,
                 actual = total_actual_size,
                 "segment size ok"
@@ -975,9 +975,9 @@ impl ReconcileJob {
         let manifest_size = segment.size;
         let delta = disk_size as i64 - manifest_size as i64;
         debug!(
-            %segment_file_name,
-            %topic_name,
-            %partition_name,
+            segment_file_name,
+            topic_name,
+            partition_name,
             manifest_size,
             disk_size,
             delta,
@@ -1009,10 +1009,10 @@ impl ReconcileJob {
         match fs::metadata(segment_path).await {
             Ok(metadata) => {
                 total_actual_size += metadata.len() as usize;
-                debug!(%segment_file_name, size = metadata.len(), "segment file size");
+                debug!(segment_file_name, size = metadata.len(), "segment file size");
             }
             Err(e) => {
-                warn!(%segment_file_name, error = ?e, "error getting metadata for segment");
+                warn!(segment_file_name, error = ?e, "error getting metadata for segment");
             }
         }
 

--- a/catalog/src/reconcile.rs
+++ b/catalog/src/reconcile.rs
@@ -533,7 +533,7 @@ impl ReconcileJob {
                 Err(e) => {
                     // Swallow the error and keep the loop alive; a transient
                     // failure on one pass must not stop reconciliation forever.
-                    error!("reconcile pass failed, continuing loop: {e:?}");
+                    error!(error = ?e, "reconcile pass failed, continuing loop");
                 }
             }
 
@@ -568,7 +568,7 @@ impl ReconcileJob {
 
             // If we're done, return true
             if done {
-                info!("Reconciliation complete: {:?}", self.report());
+                info!(report = ?self.report(), "reconciliation complete");
                 return Ok(true);
             }
 
@@ -620,7 +620,7 @@ impl ReconcileJob {
         // Get the current topic name
         let topic_name = topics[current_topic_index].clone();
 
-        debug!("Reconciling topic: {}", topic_name);
+        debug!(%topic_name, "reconciling topic");
 
         // Get all partitions for this topic
         let partitions = self.catalog.manifest().get_partitions(&topic_name).await;
@@ -645,7 +645,7 @@ impl ReconcileJob {
 
         // Process the current partition
         let partition_name = partitions[current_partition_index].clone();
-        debug!("Reconciling partition: {}/{}", topic_name, partition_name);
+        debug!(%topic_name, %partition_name, "reconciling partition");
 
         // Process this partition
         let partition_segments = self
@@ -683,8 +683,8 @@ impl ReconcileJob {
             .files_checked
             .add_paths(partition_files.clone(), partition_bytes);
         debug!(
-            "Found {} files in partition directory",
-            partition_files.len()
+            files = partition_files.len(),
+            "found files in partition directory"
         );
 
         // Highest segment index present in the tracked (manifest) snapshot per
@@ -710,7 +710,7 @@ impl ReconcileJob {
         }
 
         for file_path in partition_files {
-            debug!("Checking file: {:?}", file_path);
+            debug!(?file_path, "checking file");
             if !tracked_files.contains(&file_path) {
                 // High-water filter: suppress in-flight segment files (and their
                 // auxiliary files) sitting above the partition's highest tracked
@@ -725,15 +725,15 @@ impl ReconcileJob {
                     let in_flight = max_tracked.get(&partition).is_none_or(|max| index > *max);
                     if in_flight {
                         debug!(
-                            "Skipping in-flight segment file above tracked max: {:?}",
-                            file_path
+                            ?file_path,
+                            "skipping in-flight segment file above tracked max"
                         );
                         self.state.report.active_tail_skipped += 1;
                         continue;
                     }
                 }
 
-                warn!("Untracked file in topic {:?}: {:?}", topic_name, file_path);
+                warn!(%topic_name, ?file_path, "untracked file in topic");
                 // Add the untracked path to our stats
                 let file_size = fs::metadata(&file_path)
                     .await
@@ -744,7 +744,7 @@ impl ReconcileJob {
                     .untracked_files
                     .add_path(file_path.clone(), file_size);
             } else {
-                debug!("Found tracked path {:?}", file_path);
+                debug!(?file_path, "found tracked path");
             }
         }
 
@@ -762,10 +762,7 @@ impl ReconcileJob {
         let partition_id = PartitionId::new(topic_name, partition_name);
         let topic_path = Topic::partition_root(root, topic_name);
 
-        debug!(
-            "Processing partition {}/{} with path {:?}",
-            topic_name, partition_name, topic_path
-        );
+        debug!(%topic_name, %partition_name, ?topic_path, "processing partition");
 
         // Classify this partition's segments once for the whole pass, *without*
         // loading it into memory. A partition that is not resident is quiescent:
@@ -800,11 +797,11 @@ impl ReconcileJob {
         let segments: Vec<SegmentData> = segments_stream.collect().await;
         if let Some((start, end)) = segments.first().zip(segments.last()) {
             debug!(
-                "Fetched {} segments: {} ..= {} (resident={})",
-                segments.len(),
-                start.index.0,
-                end.index.0,
-                matches!(seal_status, SealStatus::Resident(_)),
+                count = segments.len(),
+                start = start.index.0,
+                end = end.index.0,
+                resident = matches!(seal_status, SealStatus::Resident(_)),
+                "fetched segments"
             );
         } else {
             debug!("Found no segments")
@@ -812,13 +809,13 @@ impl ReconcileJob {
 
         // Validate each segment
         for segment in segments {
-            debug!("Validating segment: {:?}", segment.index);
+            debug!(index = ?segment.index, "validating segment");
 
             let slog_name = Partition::slog_name(&partition_id);
             let segment_file_name = format!("{}-{}", slog_name, segment.index.0);
             let segment_path = Slog::segment_path(&topic_path, &slog_name, segment.index);
 
-            debug!("Checking segment file: {} at {:?}", slog_name, segment_path);
+            debug!(%slog_name, ?segment_path, "checking segment file");
 
             // Mark this file as tracked regardless of bucket so the orphan
             // detection phase does not false-positive on active segment files.
@@ -866,7 +863,7 @@ impl ReconcileJob {
     ) {
         // Check if the file exists
         if !segment_path.exists() {
-            warn!("Missing file {:?}", segment_path);
+            warn!(?segment_path, "missing file");
             // Add the missing path to our stats
             self.state
                 .report
@@ -889,15 +886,17 @@ impl ReconcileJob {
 
         // Compare total size with expected size
         debug!(
-            "Comparing sizes - total_actual_size={}, segment.size={}, diff={}",
             total_actual_size,
-            segment.size,
-            total_actual_size.abs_diff(segment.size)
+            segment_size = segment.size,
+            diff = total_actual_size.abs_diff(segment.size),
+            "comparing sizes"
         );
         if total_actual_size.abs_diff(segment.size) > 0 {
             warn!(
-                "Size mismatch for segment {}. Expected {}, actual {}",
-                segment_file_name, expected_size, actual_size
+                %segment_file_name,
+                %expected_size,
+                %actual_size,
+                "size mismatch for segment"
             );
             // Add the mismatched path to our stats
             self.state.report.sealed.size_mismatches.add_path(
@@ -931,18 +930,20 @@ impl ReconcileJob {
                     )
                     .await;
                 if applied {
-                    info!("Fixed size mismatch for segment {}", segment_file_name);
+                    info!(%segment_file_name, "fixed size mismatch for segment");
                 } else {
                     info!(
-                        "Skipped stale size fix for segment {} (concurrently removed or changed)",
-                        segment_file_name
+                        %segment_file_name,
+                        "skipped stale size fix for segment (concurrently removed or changed)"
                     );
                 }
             }
         } else {
             debug!(
-                "Segment {} size ok. Expected: {}, actual: {}",
-                segment_file_name, segment.size, total_actual_size
+                %segment_file_name,
+                expected = segment.size,
+                actual = total_actual_size,
+                "segment size ok"
             );
         }
     }
@@ -967,15 +968,20 @@ impl ReconcileJob {
             // The active segment may not have been flushed to disk yet. A zero
             // disk size against a non-zero manifest size yields a negative delta,
             // which is exactly the alert signal we want to surface.
-            debug!("Active segment file {:?} not present on disk", segment_path);
+            debug!(?segment_path, "active segment file not present on disk");
             0
         };
 
         let manifest_size = segment.size;
         let delta = disk_size as i64 - manifest_size as i64;
         debug!(
-            "Active segment {} for {}/{}: manifest_size={}, disk_size={}, delta={}",
-            segment_file_name, topic_name, partition_name, manifest_size, disk_size, delta
+            %segment_file_name,
+            %topic_name,
+            %partition_name,
+            manifest_size,
+            disk_size,
+            delta,
+            "active segment"
         );
 
         self.state.report.active.push(ActiveSegmentReport {
@@ -1003,17 +1009,10 @@ impl ReconcileJob {
         match fs::metadata(segment_path).await {
             Ok(metadata) => {
                 total_actual_size += metadata.len() as usize;
-                debug!(
-                    "Segment {} file size: {}",
-                    segment_file_name,
-                    metadata.len()
-                );
+                debug!(%segment_file_name, size = metadata.len(), "segment file size");
             }
             Err(e) => {
-                warn!(
-                    "Error getting metadata for segment {}: {:?}",
-                    segment_file_name, e
-                );
+                warn!(%segment_file_name, error = ?e, "error getting metadata for segment");
             }
         }
 
@@ -1028,14 +1027,14 @@ impl ReconcileJob {
                 match fs::metadata(&part_path).await {
                     Ok(metadata) => {
                         total_actual_size += metadata.len() as usize;
-                        debug!("Part {:?} size: {}", part_path, metadata.len());
+                        debug!(?part_path, size = metadata.len(), "part size");
                     }
                     Err(e) => {
-                        warn!("Error getting metadata for part {:?}: {:?}", part_path, e);
+                        warn!(?part_path, error = ?e, "error getting metadata for part");
                     }
                 }
             } else {
-                debug!("Part {:?} does not exist", part_path);
+                debug!(?part_path, "part does not exist");
             }
         }
 
@@ -1310,14 +1309,14 @@ mod tests {
         let topic_root = catalog.topic_root().join("test-topic");
         // Orphan files are created in the topic directory, not partition subdirectory
         let partition_path = topic_root.clone();
-        trace!("Topic root: {:?}", topic_root);
-        trace!("Partition path (topic directory): {:?}", partition_path);
-        trace!("Partition path exists: {}", partition_path.exists());
+        trace!(?topic_root);
+        trace!(?partition_path, "partition path (topic directory)");
+        trace!(exists = partition_path.exists(), "partition path exists");
 
         if partition_path.exists() {
             let mut entries = fs::read_dir(&partition_path).await?;
             while let Some(entry) = entries.next_entry().await? {
-                trace!("Existing file: {:?}", entry.file_name());
+                trace!(file_name = ?entry.file_name(), "existing file");
             }
         } else {
             // Create the directory if it doesn't exist

--- a/catalog/src/slog.rs
+++ b/catalog/src/slog.rs
@@ -674,11 +674,11 @@ fn spawn_slog_thread(
                     full_chunks,
                     active_chunk,
                 })) => {
-                    trace!(%name, ?records, "received request");
+                    trace!(name, ?records, "received request");
                     let new_segment = Slog::segment_from_name(&root, &name, segment);
                     current = current.and_then(|(schema, writer, id)| {
                         if id != segment {
-                            trace!(%name, ?id, ?segment, "segment change");
+                            trace!(name, ?id, ?segment, "segment change");
                             writer.close().expect("sealed segment");
                             None
                         } else {
@@ -686,7 +686,7 @@ fn spawn_slog_thread(
                         }
                     });
                     let (schema, ref mut writer, _) = current.get_or_insert_with(|| {
-                        trace!(%name, ?segment, "opening segment");
+                        trace!(name, ?segment, "opening segment");
                         (
                             schema.clone(),
                             new_segment
@@ -704,7 +704,7 @@ fn spawn_slog_thread(
                     let mut size = writer.size_estimate().expect("segment size estimate");
                     let record_len = records.end.0 - records.start.0;
                     debug!(
-                        %name,
+                        name,
                         ?segment,
                         end = ?records.end,
                         len = record_len,
@@ -724,7 +724,7 @@ fn spawn_slog_thread(
                         if let Some((_, w, _)) = current.take() {
                             size = w.close().expect("segment close");
                         }
-                        trace!(%size, %name, ?segment, ?records, "sealed");
+                        trace!(size, name, ?segment, ?records, "sealed");
                     }
 
                     let response = WriteResult {
@@ -737,9 +737,9 @@ fn spawn_slog_thread(
                         },
                         sealed: seal,
                     };
-                    trace!(%name, ?segment, end = ?records.end, "commit send");
+                    trace!(name, ?segment, end = ?records.end, "commit send");
                     tx_commits.blocking_send(response).expect("channel closed");
-                    trace!(%name, "commit sent");
+                    trace!(name, "commit sent");
                 }
                 Some(WriterMessage::Fin) | None => {
                     trace!("channel closed; shutting down");
@@ -754,7 +754,7 @@ fn spawn_slog_thread(
         }
 
         current.take().map(|(_, writer, _)| writer.close());
-        info!(%name, "writer closed");
+        info!(name, "writer closed");
     });
 
     (SlogThread { tx, tx_fin, handle }, rx_commits)

--- a/catalog/src/slog.rs
+++ b/catalog/src/slog.rs
@@ -240,26 +240,26 @@ impl MemorySegment {
                 let prior_start = start_ix;
                 start_ix = ix + 1;
                 trace!(
-                    "full chunk {:?} {}",
-                    prior_start..start_ix,
-                    partial.total_rows
+                    range = ?(prior_start..start_ix),
+                    rows = partial.total_rows,
+                    "full chunk"
                 );
                 match std::mem::take(&mut partial).concat() {
                     Ok((chunk, bytes)) => compact.push(chunk, bytes),
-                    Err(e) => error!("error building full chunk: {:?}", e),
+                    Err(e) => error!(error = ?e, "error building full chunk"),
                 }
             }
         }
 
         if !partial.is_empty() {
             trace!(
-                "compact active segment {:?} {}",
-                start_ix..(start_ix + partial.len()),
-                partial.total_rows
+                range = ?(start_ix..(start_ix + partial.len())),
+                rows = partial.total_rows,
+                "compact active segment"
             );
             match partial.concat() {
                 Ok((chunk, bytes)) => compact.push(chunk, bytes),
-                Err(e) => error!("error building final partial chunk: {:?}", e),
+                Err(e) => error!(error = ?e, "error building final partial chunk"),
             };
         }
 
@@ -437,9 +437,9 @@ impl Slog {
         let matches = active.as_ref().is_none_or(|s| &s.schema == other);
         if !matches {
             trace!(
-                "schema mismatch: {:?} != {:?}",
-                active.as_ref().map(|s| &s.schema),
-                other
+                active = ?active.as_ref().map(|s| &s.schema),
+                ?other,
+                "schema mismatch"
             );
         }
 
@@ -470,7 +470,7 @@ impl Slog {
     }
 
     pub(crate) async fn checkpoint(&self) -> bool {
-        trace!("checkpoint {:?}", self.root);
+        trace!(root = ?self.root, "checkpoint");
         self.state.write().await.checkpoint(false).await
     }
 
@@ -489,7 +489,7 @@ impl State {
         let bytes = match estimate_size(&d.chunk) {
             Ok(size) => size,
             Err(e) => {
-                error!("error estimating chunk size: {e:?}");
+                error!(error = ?e, "error estimating chunk size");
                 len
             }
         };
@@ -581,12 +581,12 @@ impl State {
                 };
 
                 trace!(
-                    "{:?}: {:?} (seal: {}, full chunks: {}, active rows: {})",
-                    segment.metadata.index,
-                    records,
+                    index = ?segment.metadata.index,
+                    ?records,
                     seal,
-                    full_chunks.len(),
-                    active_chunk.len()
+                    full_chunks = full_chunks.len(),
+                    active_rows = active_chunk.len(),
+                    "checkpoint segment"
                 );
 
                 if timeout(
@@ -618,7 +618,7 @@ impl State {
         if let Some(records) = self.active.as_ref().map(|s| s.record_count()) {
             if self.checkpoint(true).await {
                 let segment = self.active_checkpoint.segment;
-                trace!("rolling {:?}", segment);
+                trace!(?segment, "rolling");
                 self.active_checkpoint.segment = segment.next();
                 self.active_first_record_ix += records;
                 self.pending = self.active.take();
@@ -636,9 +636,9 @@ impl State {
         self.thread.tx_fin.send(()).ok();
         self.thread.tx.send(WriterMessage::Fin).await.ok();
         if let Err(e) = self.thread.handle.join() {
-            error!("error joining writer thread: {:?}", e);
+            error!(error = ?e, "error joining writer thread");
         }
-        info!("writer thread shutdown in {:?}", now.elapsed());
+        info!(elapsed = ?now.elapsed(), "writer thread shutdown");
     }
 }
 
@@ -674,11 +674,11 @@ fn spawn_slog_thread(
                     full_chunks,
                     active_chunk,
                 })) => {
-                    trace!("{}: received request for {:?}", name, records);
+                    trace!(%name, ?records, "received request");
                     let new_segment = Slog::segment_from_name(&root, &name, segment);
                     current = current.and_then(|(schema, writer, id)| {
                         if id != segment {
-                            trace!("{}: segment change {:?} {:?}", name, id, segment);
+                            trace!(%name, ?id, ?segment, "segment change");
                             writer.close().expect("sealed segment");
                             None
                         } else {
@@ -686,7 +686,7 @@ fn spawn_slog_thread(
                         }
                     });
                     let (schema, ref mut writer, _) = current.get_or_insert_with(|| {
-                        trace!("{}: opening segment {:?}", name, segment);
+                        trace!(%name, ?segment, "opening segment");
                         (
                             schema.clone(),
                             new_segment
@@ -704,13 +704,13 @@ fn spawn_slog_thread(
                     let mut size = writer.size_estimate().expect("segment size estimate");
                     let record_len = records.end.0 - records.start.0;
                     debug!(
-                        "{}: wrote to {:?} (end {:?}, len {}, size {}) in {:?}",
-                        name,
-                        segment,
-                        records.end,
-                        record_len,
-                        size - prior_size,
-                        now.elapsed()
+                        %name,
+                        ?segment,
+                        end = ?records.end,
+                        len = record_len,
+                        size = size - prior_size,
+                        elapsed = ?now.elapsed(),
+                        "wrote to segment"
                     );
                     prior_size = size;
                     counter!(
@@ -724,7 +724,7 @@ fn spawn_slog_thread(
                         if let Some((_, w, _)) = current.take() {
                             size = w.close().expect("segment close");
                         }
-                        trace!(%size, "{}: sealed {:?} {:?}", name, segment, records);
+                        trace!(%size, %name, ?segment, ?records, "sealed");
                     }
 
                     let response = WriteResult {
@@ -737,9 +737,9 @@ fn spawn_slog_thread(
                         },
                         sealed: seal,
                     };
-                    trace!("{}: commit {:?}/{:?} send", name, segment, records.end);
+                    trace!(%name, ?segment, end = ?records.end, "commit send");
                     tx_commits.blocking_send(response).expect("channel closed");
-                    trace!("{}: commit sent", name);
+                    trace!(%name, "commit sent");
                 }
                 Some(WriterMessage::Fin) | None => {
                     trace!("channel closed; shutting down");
@@ -754,7 +754,7 @@ fn spawn_slog_thread(
         }
 
         current.take().map(|(_, writer, _)| writer.close());
-        info!("writer for \"{}\" closed", name);
+        info!(%name, "writer closed");
     });
 
     (SlogThread { tx, tx_fin, handle }, rx_commits)

--- a/catalog/src/storage.rs
+++ b/catalog/src/storage.rs
@@ -78,7 +78,7 @@ impl DiskMonitor {
         let path = root.to_path_buf();
         let path = spawn_blocking(|| canonical_mount(path)).await??;
 
-        info!("storage monitor starting for {root:?} (mount point: {path:?})");
+        info!(?root, mount_point = ?path, "storage monitor starting");
 
         loop {
             let deadline = self

--- a/catalog/src/topic.rs
+++ b/catalog/src/topic.rs
@@ -75,7 +75,7 @@ impl Topic {
         &self,
         partition_filter: PartitionFilter,
     ) -> HashMap<String, Range<RecordIndex>> {
-        debug!("partition map: {:?}", self.partitions);
+        debug!(partitions = ?self.partitions, "partition map");
         self.map_partitions(
             |partition| async move { partition.readable_ids().await },
             partition_filter,

--- a/client/src/batch.rs
+++ b/client/src/batch.rs
@@ -81,7 +81,7 @@ impl BatchClient {
             .await
             .map_err(|e| match e {
                 ClientError::RequestTooLong(_, MaxRequestSize(Some(s))) => {
-                    warn!(max_row_size = %s, "detected new max plateau row size");
+                    warn!(max_row_size = s, "detected new max plateau row size");
                     update_default_max_batch_bytes(s);
                     self.max_batch_bytes = s;
                     BatchSendError::Resize
@@ -153,7 +153,7 @@ pub trait Batch: Sized {
                 self.split_into(bytes / max_bytes + 1)
             } else if self.prune().is_none() {
                 error!(
-                    %bytes,
+                    bytes,
                     "inference log batch is too large to send, and cannot be reduced"
                 );
                 vec![]

--- a/client/src/batch.rs
+++ b/client/src/batch.rs
@@ -81,7 +81,7 @@ impl BatchClient {
             .await
             .map_err(|e| match e {
                 ClientError::RequestTooLong(_, MaxRequestSize(Some(s))) => {
-                    warn!("detected new max plateau row size: {s}");
+                    warn!(max_row_size = %s, "detected new max plateau row size");
                     update_default_max_batch_bytes(s);
                     self.max_batch_bytes = s;
                     BatchSendError::Resize
@@ -152,7 +152,10 @@ pub trait Batch: Sized {
             if self.len() > 1 {
                 self.split_into(bytes / max_bytes + 1)
             } else if self.prune().is_none() {
-                error!("inference log batch is too large to send ({bytes} bytes), and cannot be reduced");
+                error!(
+                    %bytes,
+                    "inference log batch is too large to send, and cannot be reduced"
+                );
                 vec![]
             } else {
                 vec![self]
@@ -200,7 +203,7 @@ impl<T: Clone + Batch + Send + 'static, C: BatchSender<Batch = T>> WorkerPool<T,
             .sender
             .send(batch)
             .await
-            .unwrap_or_else(|e| error!("queueing batch to worker failed: {e}"));
+            .unwrap_or_else(|e| error!(error = %e, "queueing batch to worker failed"));
     }
 
     /// Flush all pending work and shut down workers

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -366,8 +366,8 @@ impl Client {
                 // reshape of a non-empty queue must also be non-empty
                 front = queue.front()?.unwrap();
                 warn!(
-                    %max_rows,
-                    bytes = %front.bytes.len(),
+                    max_rows,
+                    bytes = front.bytes.len(),
                     "decreasing inferred max row count"
                 );
             }
@@ -387,7 +387,7 @@ impl Client {
                 Err(e) => {
                     if let Error::RequestTooLong(request_size, MaxRequestSize(Some(s))) = e {
                         if front.rows > 1 {
-                            warn!(max_batch_bytes = %s, "detected new max plateau batch byte limit");
+                            warn!(max_batch_bytes = s, "detected new max plateau batch byte limit");
                             self.max_batch_bytes = s;
                             // return to sender: because we don't pop_front here
                             // we'll start again from the top with the new limit

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -387,7 +387,10 @@ impl Client {
                 Err(e) => {
                     if let Error::RequestTooLong(request_size, MaxRequestSize(Some(s))) = e {
                         if front.rows > 1 {
-                            warn!(max_batch_bytes = s, "detected new max plateau batch byte limit");
+                            warn!(
+                                max_batch_bytes = s,
+                                "detected new max plateau batch byte limit"
+                            );
                             self.max_batch_bytes = s;
                             // return to sender: because we don't pop_front here
                             // we'll start again from the top with the new limit

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -366,8 +366,9 @@ impl Client {
                 // reshape of a non-empty queue must also be non-empty
                 front = queue.front()?.unwrap();
                 warn!(
-                    "decreasing inferred max row count: {max_rows} ({} bytes)",
-                    front.bytes.len()
+                    %max_rows,
+                    bytes = %front.bytes.len(),
+                    "decreasing inferred max row count"
                 );
             }
 
@@ -386,7 +387,7 @@ impl Client {
                 Err(e) => {
                     if let Error::RequestTooLong(request_size, MaxRequestSize(Some(s))) = e {
                         if front.rows > 1 {
-                            warn!("detected new max plateau batch byte limit: {s}");
+                            warn!(max_batch_bytes = %s, "detected new max plateau batch byte limit");
                             self.max_batch_bytes = s;
                             // return to sender: because we don't pop_front here
                             // we'll start again from the top with the new limit
@@ -818,7 +819,7 @@ impl IterateUnlimited<polars::frame::DataFrame> for Client {
             )
             .await?;
 
-            tracing::debug!("Iterate Unlimited Response: {:?}", response);
+            tracing::debug!(?response, "iterate unlimited response");
 
             let headers = response.headers().get("x-iteration-status").cloned();
 

--- a/client/src/replicate.rs
+++ b/client/src/replicate.rs
@@ -110,8 +110,11 @@ impl ReplicatePartitionJob {
 
             if let Some(insert) = insert {
                 debug!(
-                    "{} => {}: {} => {}",
-                    self.source, self.target, self.record_ix, insert.span.end
+                    source = %self.source,
+                    target = %self.target,
+                    from_ix = self.record_ix,
+                    to_ix = insert.span.end,
+                    "replicated records"
                 );
 
                 self.record_ix = insert.span.end;
@@ -122,8 +125,10 @@ impl ReplicatePartitionJob {
             Ok(false)
         } else {
             debug!(
-                "{} => {}: up to date at {}",
-                self.source, self.target, self.record_ix
+                source = %self.source,
+                target = %self.target,
+                record_ix = self.record_ix,
+                "partition up to date"
             );
 
             Ok(true)
@@ -280,7 +285,7 @@ impl ReplicationWorker {
             .await?;
 
         for (id, (url, _)) in &hosts {
-            info!("{} url: {}", id, url);
+            info!(host_id = %id, %url, "known host");
         }
 
         Ok(Self {
@@ -335,15 +340,22 @@ impl ReplicationWorker {
     pub async fn pump(&mut self) -> Result<(), Error> {
         for job in self.all_jobs() {
             info!(
-                "start: {} => {} @ {}",
-                job.source, job.target, job.record_ix
+                source = %job.source,
+                target = %job.target,
+                record_ix = job.record_ix,
+                "starting replication job"
             )
         }
 
         while !self.page_all().await? {}
 
         for job in self.all_jobs() {
-            info!("end: {} => {} @ {}", job.source, job.target, job.record_ix)
+            info!(
+                source = %job.source,
+                target = %job.target,
+                record_ix = job.record_ix,
+                "finished replication job"
+            )
         }
 
         Ok(())
@@ -383,9 +395,9 @@ impl ReplicationWorker {
                     tokio::time::sleep(period).await;
                 }
                 Err(e) => {
-                    error!("error in loop: {:?}", e);
+                    error!(error = %e, "error in loop");
                     let next = backoff.next_backoff();
-                    info!("waiting {:.1?} to retry", last_duration);
+                    info!(delay = ?last_duration, "waiting to retry");
                     tokio::time::sleep(last_duration).await;
                     last_duration = next.unwrap_or(last_duration)
                 }

--- a/client/src/replicate.rs
+++ b/client/src/replicate.rs
@@ -395,7 +395,7 @@ impl ReplicationWorker {
                     tokio::time::sleep(period).await;
                 }
                 Err(e) => {
-                    error!(error = %e, "error in loop");
+                    error!(error = ?e, "error in loop");
                     let next = backoff.next_backoff();
                     info!(delay = ?last_duration, "waiting to retry");
                     tokio::time::sleep(last_duration).await;

--- a/client/src/replicate.rs
+++ b/client/src/replicate.rs
@@ -285,7 +285,7 @@ impl ReplicationWorker {
             .await?;
 
         for (id, (url, _)) in &hosts {
-            info!(host_id = %id, %url, "known host");
+            info!(host_id = id, url, "known host");
         }
 
         Ok(Self {

--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -44,7 +44,7 @@ fn remove_file_if_present(path: &Path) -> Result<()> {
     match fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            warn!("attempted to remove missing file {:?}", path);
+            warn!(?path, "attempted to remove missing file");
             Ok(())
         }
         other => other.context(format!("removing {path:?}")),
@@ -98,7 +98,7 @@ impl Segment {
 
     fn file(&self) -> Result<fs::File> {
         if self.path.exists() {
-            warn!("truncating extant segment file at {}", self.path.display());
+            warn!(path = %self.path.display(), "truncating extant segment file");
         }
 
         Ok(fs::OpenOptions::new()
@@ -129,7 +129,9 @@ impl Segment {
     pub fn parts(&self) -> impl Iterator<Item = PathBuf> {
         let arrow_parts = arrow::Segment::new(self.path.clone())
             .map(|s| s.parts())
-            .inspect_err(|e| error!("error enumerating parquet parts for {:?}, {e:?}", self.path))
+            .inspect_err(
+                |e| error!(path = ?self.path, error = ?e, "error enumerating parquet parts"),
+            )
             .ok();
 
         arrow_parts.into_iter().flatten()
@@ -159,7 +161,7 @@ impl Segment {
         match self.iter() {
             Ok(_) => true,
             Err(err) => {
-                warn!("error validating segment: {err:?}");
+                warn!(?err, "error validating segment");
                 false
             }
         }
@@ -167,16 +169,12 @@ impl Segment {
 
     pub fn iter(&self) -> Result<impl SegmentIterator> {
         let cache = cache::read(self.cache_path()).unwrap_or_else(|err| {
-            error!("error reading cache at {:?}: {err:?}", self.cache_path());
+            error!(cache_path = ?self.cache_path(), ?err, "error reading cache");
             None
         });
 
         if self.path.exists() {
-            trace!(
-                "found segment file {:?}, cache: {}",
-                self.path,
-                cache.is_some()
-            );
+            trace!(path = ?self.path, has_cache = cache.is_some(), "found segment file");
             let mut file = fs::File::open(&self.path)?;
 
             // Check for a header
@@ -184,10 +182,10 @@ impl Segment {
             let arrow = arrow::check_file(&mut file);
             if let (Ok(parquet), Ok(arrow)) = (parquet, arrow) {
                 return if parquet {
-                    trace!("{:?} in parquet format", self.path);
+                    trace!(path = ?self.path, "in parquet format");
                     anyhow::bail!("parquet format is no longer supported");
                 } else if arrow {
-                    trace!("{:?} in arrow format", self.path);
+                    trace!(path = ?self.path, "in arrow format");
                     let segment = arrow::Segment::new(self.path.clone())?;
                     Ok(ReadFormat::Arrow(segment.read(cache)?))
                 } else {
@@ -195,7 +193,7 @@ impl Segment {
                 };
             }
 
-            trace!("empty segment file {:?}", self.path);
+            trace!(path = ?self.path, "empty segment file");
         }
 
         if let Some(data) = cache {
@@ -614,7 +612,7 @@ pub mod test {
 
         let all_counts = [1, 3, 4, 2, 1];
         for ix in 1..all_counts.len() {
-            trace!("iter: {ix} counts: 1 + {:?}", &all_counts[0..ix]);
+            trace!(ix, additional_counts = ?&all_counts[0..ix], "iter counts");
             let mut chunk = a.chunk.clone();
 
             let path = root.path().join(format!("{ix:?}.arrow"));

--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -129,9 +129,7 @@ impl Segment {
     pub fn parts(&self) -> impl Iterator<Item = PathBuf> {
         let arrow_parts = arrow::Segment::new(self.path.clone())
             .map(|s| s.parts())
-            .inspect_err(
-                |e| error!(path = ?self.path, error = ?e, "error enumerating arrow parts"),
-            )
+            .inspect_err(|e| error!(path = ?self.path, error = ?e, "error enumerating arrow parts"))
             .ok();
 
         arrow_parts.into_iter().flatten()

--- a/data/src/segment.rs
+++ b/data/src/segment.rs
@@ -130,7 +130,7 @@ impl Segment {
         let arrow_parts = arrow::Segment::new(self.path.clone())
             .map(|s| s.parts())
             .inspect_err(
-                |e| error!(path = ?self.path, error = ?e, "error enumerating parquet parts"),
+                |e| error!(path = ?self.path, error = ?e, "error enumerating arrow parts"),
             )
             .ok();
 

--- a/data/src/segment/arrow.rs
+++ b/data/src/segment/arrow.rs
@@ -35,7 +35,7 @@ pub fn check_file(f: &mut fs::File) -> anyhow::Result<bool> {
     // Handle empty files
     match f.read_exact(&mut buffer) {
         Ok(_) => {
-            trace!("Read header bytes: {:?}", buffer);
+            trace!(?buffer, "read header bytes");
             Ok(buffer.into_iter().eq(ARROW_HEADER.bytes()))
         }
         Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
@@ -88,7 +88,7 @@ impl Segment {
     }
 
     fn recover(&self, cache: Option<cache::Data>) -> anyhow::Result<(usize, Reader)> {
-        warn!("beginning recovery of {:?}", self.path);
+        warn!(path = ?self.path, "beginning recovery");
 
         // Combine all readable data from a damaged (partially written) segment with
         // the data from cache into a new, "recovered" file.
@@ -104,7 +104,7 @@ impl Segment {
                 let schema = stream_reader.schema();
                 Ok((stream_reader, schema))
             })
-            .map_err(|e| error!("error reading {:?}: {e:?}", self.path))
+            .map_err(|e| error!(path = ?self.path, error = ?e, "error reading"))
             .ok()
             .unzip();
 
@@ -122,8 +122,8 @@ impl Segment {
                     // the cache as it should always have fewer rows than even a
                     // single chunk.
                     warn!(
-                        "segment schema does not match cache schema. discarding {} rows from cache",
-                        cache.rows.chunk.len()
+                        rows = cache.rows.chunk.len(),
+                        "segment schema does not match cache schema, discarding rows from cache"
                     );
                     (a, None)
                 } else {
@@ -170,8 +170,8 @@ impl Segment {
             }
         } else if let Some(chunk_ix) = chunk_ix {
             warn!(
-                "gap between chunks in file ({}) and cache index ({})",
-                recovered_chunks, chunk_ix
+                recovered_chunks,
+                chunk_ix, "gap between chunks in file and cache index"
             );
             cache_recovery = "(cache invalid)"
         }
@@ -179,8 +179,11 @@ impl Segment {
         writer.finish()?;
         writer.into_inner()?.sync_all()?;
         warn!(
-            "recovered {recovered_rows} rows in {recovered_chunks} chunks from {:?} {cache_recovery}",
-            self.path,
+            recovered_rows,
+            recovered_chunks,
+            path = ?self.path,
+            cache_recovery,
+            "recovered rows in chunks"
         );
 
         // Now, we should be able to read normally from the recovered file.

--- a/data/src/segment/cache.rs
+++ b/data/src/segment/cache.rs
@@ -98,7 +98,11 @@ pub struct Writer {
 
 impl Writer {
     pub fn new(path: PathBuf, initial: SchemaChunk<Schema>, chunk_ix: u32) -> Result<Self> {
-        trace!("start {:?} with {}", path, initial.chunk.len());
+        trace!(
+            ?path,
+            initial_rows = initial.chunk.len(),
+            "starting cache writer"
+        );
         let mut file = fs::File::create(&path)?;
         file.write_all(PLATEAU_HEADER.as_bytes())?;
 
@@ -131,7 +135,7 @@ impl Writer {
 
         let new_len = chunk.len();
         let additional = crate::chunk::slice(chunk.clone(), self.len(), new_len - self.len());
-        trace!("{} => {}", self.len(), chunk.len());
+        trace!(from = self.len(), to = chunk.len(), "updating cache");
         self.writer
             .write(&additional.to_record_batch(&self.partial.schema)?)?;
         self.partial.chunk = chunk;
@@ -142,7 +146,7 @@ impl Writer {
     pub(super) fn sync(&self) -> Result<()> {
         let now = Instant::now();
         self.file.sync_data()?;
-        debug!("cache sync elapsed: {:?}", now.elapsed());
+        debug!(elapsed = ?now.elapsed(), "cache sync elapsed");
 
         Ok(())
     }
@@ -174,10 +178,7 @@ pub fn read(path: PathBuf) -> Result<Option<Data>> {
         let stream_reader = match StreamReader::try_new(&mut reader, None) {
             Ok(reader) => reader,
             Err(e) => {
-                error!(
-                    "Error creating stream reader for cache file {:?}: {}",
-                    path, e
-                );
+                error!(?path, %e, "error creating stream reader for cache file");
                 return Ok(None);
             }
         };
@@ -190,7 +191,7 @@ pub fn read(path: PathBuf) -> Result<Option<Data>> {
                     chunks.push(SegmentChunk::from_record_batch(batch));
                 }
                 Err(e) => {
-                    error!("error reading cache segment: {:?}", e);
+                    error!(?e, "error reading cache segment");
                 }
             }
         }
@@ -199,14 +200,14 @@ pub fn read(path: PathBuf) -> Result<Option<Data>> {
             // This can really only happen if plateau / the system crashes while
             // writing the first chunk to the stream. That seems unlikely enough
             // to warn about.
-            warn!("could not read any chunks from cache at {:?}", path);
+            warn!(?path, "could not read any chunks from cache");
             return Ok(None);
         } else {
             let chunk = crate::chunk::concatenate(&chunks)?;
             trace!(
-                "read {} rows ({} chunks) from cache",
-                chunk.len(),
-                chunks.len()
+                rows = chunk.len(),
+                chunks = chunks.len(),
+                "read rows from cache"
             );
             chunk
         };

--- a/data/src/segment/parquet.rs
+++ b/data/src/segment/parquet.rs
@@ -211,7 +211,7 @@ impl Writer {
             // footer is useless without the corresponding data it describes.
             checkpoint_file.sync_data()?;
             drop(checkpoint_file);
-            debug!("file sync elapsed: {:?}", now.elapsed());
+            debug!(elapsed = ?now.elapsed(), "file sync elapsed");
         }
 
         fs::rename(
@@ -224,7 +224,7 @@ impl Writer {
             // the checkpoint file
             let now = Instant::now();
             self.directory.sync_all()?;
-            debug!("dir sync elapsed: {:?}", now.elapsed());
+            debug!(elapsed = ?now.elapsed(), "dir sync elapsed");
         }
 
         Ok(())
@@ -246,7 +246,7 @@ fn recover(
 ) -> anyhow::Result<FileMetaData> {
     let path = path.as_ref();
     let checkpoint_path = checkpoint_path.as_ref();
-    warn!("attempting to recover checkpoint {:?}", checkpoint_path);
+    warn!(?checkpoint_path, "attempting to recover checkpoint");
 
     {
         let mut checkpoint = fs::File::open(checkpoint_path)?;
@@ -257,9 +257,9 @@ fn recover(
         checkpoint.read_exact(&mut buffer)?;
         let offset = u64::from_le_bytes(buffer);
         debug!(
-            "found valid v1 checkpoint at offset {} (file length {})",
             offset,
-            segment.metadata()?.len()
+            file_length = segment.metadata()?.len(),
+            "found valid v1 checkpoint"
         );
 
         #[allow(clippy::unbuffered_bytes)]
@@ -269,13 +269,13 @@ fn recover(
         segment.seek(SeekFrom::Start(offset))?;
         segment.write_all(&rest)?;
         segment.write_all(PARQUET_HEADER.as_bytes())?;
-        warn!("successfully recovered checkpoint {:?}", checkpoint_path);
+        warn!(?checkpoint_path, "successfully recovered checkpoint");
     }
 
     let mut f = fs::File::open(path)?;
     let metadata = read_metadata(&mut f)?;
 
-    debug!("recovered {} rows", metadata.num_rows);
+    debug!(rows = metadata.num_rows, "recovered rows");
 
     Ok(metadata)
 }
@@ -302,7 +302,7 @@ impl Reader {
                 })
             }
             Err(err) => {
-                error!("error opening segment file: {err:?}");
+                error!(?err, "error opening segment file");
                 cache
                     .map(|cache| Self {
                         schema: cache.rows.schema,
@@ -347,7 +347,7 @@ impl CachingReader {
         let mut f = fs::File::open(&segment.path)?;
 
         let metadata = read_metadata(&mut f).or_else(|err| {
-            debug!("error reading segment: {err:?}");
+            debug!(?err, "error reading segment");
             drop(f);
             anyhow::ensure!(
                 segment.checkpoint_path.exists(),
@@ -390,7 +390,7 @@ impl Iterator for CachingReader {
                 match self.reader.next() {
                     Some(Ok(chunk)) => self.chunks.push(chunk),
                     Some(Err(e)) => {
-                        error!("failed to read chunk from segment: {e}");
+                        error!(%e, "failed to read chunk from segment");
                         return Some(Err(e.into()));
                     }
                     None => {}

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -29,10 +29,10 @@ impl PlateauConfig {
         match self.to_string_pretty() {
             Ok(c) => {
                 for line in c.lines() {
-                    info!("config toml: {}", line);
+                    info!(%line, "config toml");
                 }
             }
-            Err(e) => error!("{}", e),
+            Err(e) => error!(%e, "failed to format config"),
         }
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -29,7 +29,7 @@ impl PlateauConfig {
         match self.to_string_pretty() {
             Ok(c) => {
                 for line in c.lines() {
-                    info!(%line, "config toml");
+                    info!(line, "config toml");
                 }
             }
             Err(e) => error!(%e, "failed to format config"),

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -171,7 +171,7 @@ pub async fn serve(
 
     let fut = server.with_graceful_shutdown(FutureExt::map(rx_shutdown, |_| ()));
     let span = tracing::info_span!("Server::run", ?addr);
-    tracing::info!(parent: &span, "listening on http://{}", addr);
+    tracing::info!(parent: &span, %addr, "listening");
 
     (
         addr,
@@ -255,10 +255,10 @@ async fn topic_append_internal(
 
     let topic = catalog.get_topic(&topic_name).await;
     info!(
-        "appending {} to {}/{}",
-        chunk.0.len(),
-        topic_name,
-        partition_name
+        len = chunk.0.len(),
+        %topic_name,
+        %partition_name,
+        "appending records"
     );
     let r = topic.extend(&partition_name, chunk.0).await;
 

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -256,9 +256,7 @@ async fn topic_append_internal(
     let topic = catalog.get_topic(&topic_name).await;
     info!(
         len = chunk.0.len(),
-        topic_name,
-        partition_name,
-        "appending records"
+        topic_name, partition_name, "appending records"
     );
     let r = topic.extend(&partition_name, chunk.0).await;
 

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -256,8 +256,8 @@ async fn topic_append_internal(
     let topic = catalog.get_topic(&topic_name).await;
     info!(
         len = chunk.0.len(),
-        %topic_name,
-        %partition_name,
+        topic_name,
+        partition_name,
         "appending records"
     );
     let r = topic.extend(&partition_name, chunk.0).await;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -94,10 +94,7 @@ pub async fn task_from_catalog_config(
         // joins the shutdown race here: when `stop` (or the server) wins the
         // `select_all`, this future is dropped, cleanly cancelling the loop.
         if let Some(reconcile_config) = config.reconcile.clone() {
-            tracing::info!(
-                "starting continuous reconciliation loop with config: {:?}",
-                reconcile_config
-            );
+            tracing::info!(?reconcile_config, "starting continuous reconciliation loop");
             tasks.push(catalog::ReconcileJob::run_loop(catalog.clone(), reconcile_config).boxed());
         }
 

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -49,7 +49,7 @@ pub async fn run(mut config: Config, addr: SocketAddr) {
             error!(?result, "unexpectedly exited loop");
         }
         Err(e) => {
-            error!(%e, "config error")
+            error!(?e, "config error")
         }
     }
 }

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -45,13 +45,11 @@ pub async fn run(mut config: Config, addr: SocketAddr) {
 
     match ReplicationWorker::from_replicate(config.replicate).await {
         Ok(replication) => {
-            error!(
-                "unexpectedly exited loop: {:?}",
-                replication.run_forever(config.period, backoff).await
-            );
+            let result = replication.run_forever(config.period, backoff).await;
+            error!(?result, "unexpectedly exited loop");
         }
         Err(e) => {
-            error!("config error: {:?}", e)
+            error!(%e, "config error")
         }
     }
 }

--- a/server/tests/server.rs
+++ b/server/tests/server.rs
@@ -1014,7 +1014,7 @@ async fn info_endpoint() -> Result<()> {
     let pretty_json = serde_json::to_string_pretty(&info_response)?;
     tracing::debug!("Info endpoint response:");
     for line in pretty_json.lines() {
-        tracing::debug!(%line, "info endpoint response line");
+        tracing::debug!(line, "info endpoint response line");
     }
 
     // Should have 2 topics

--- a/server/tests/server.rs
+++ b/server/tests/server.rs
@@ -239,7 +239,7 @@ fn partition_records_url(
 
 fn assert_status(response: &Response, expected: &str) {
     let header = response.headers().get(ITERATION_STATUS_HEADER).unwrap();
-    trace!("{header:?}");
+    trace!(?header);
     let status: json::Value = json::from_str(header.to_str().unwrap()).unwrap();
     let status = status
         .as_object()
@@ -253,7 +253,7 @@ fn assert_status(response: &Response, expected: &str) {
 
 fn assert_partition_status(response: &Response, expected: &str) {
     let header = response.headers().get(ITERATION_STATUS_HEADER).unwrap();
-    trace!("{header:?}");
+    trace!(?header);
     assert_eq!(header.to_str().unwrap(), format!("{expected:?}"));
 }
 
@@ -452,7 +452,7 @@ async fn max_request_header() -> Result<()> {
 
     let status = resp.status();
     let headers = resp.headers().clone();
-    trace!("{status}, {:?}", resp.text().await);
+    trace!(%status, body = ?resp.text().await, "oversized append response");
     assert_eq!(413, status);
     assert_eq!(
         &max.to_string(),
@@ -1014,7 +1014,7 @@ async fn info_endpoint() -> Result<()> {
     let pretty_json = serde_json::to_string_pretty(&info_response)?;
     tracing::debug!("Info endpoint response:");
     for line in pretty_json.lines() {
-        tracing::debug!("{}", line);
+        tracing::debug!(%line, "info endpoint response line");
     }
 
     // Should have 2 topics


### PR DESCRIPTION
## Summary
- Replace formatted string log messages (`trace!("...", value)`) with structured tracing fields (`%value` / `?value` / `key = value`) across the workspace, making log output queryable and consistent with tracing's structured-logging model.
- Drop redundant log messages that just repeated the field name (e.g. `debug!(%seed, "seed")` -> `debug!(%seed)`).

## Test plan
- [x] `cargo clippy --workspace --all-targets` passes clean
- [x] `cargo check --workspace` passes